### PR TITLE
Fix whoogle maintainer url

### DIFF
--- a/src/lib/data/themes.json
+++ b/src/lib/data/themes.json
@@ -614,7 +614,7 @@
 		"maintainers": [
 			{
 				"name": "ThatOneCalculator",
-				"url": "https://github.com/github"
+				"url": "https://github.com/thatonecalculator"
 			}
 		],
 		"keywords": ["web"],


### PR DESCRIPTION
not sure why the others had `github.com/github` lol