### PR TITLE
add wezterm

### DIFF
--- a/src/lib/data/themes.json
+++ b/src/lib/data/themes.json
@@ -629,6 +629,18 @@
 		"keywords": ["design"]
 	},
 	{
+		"name": "WezTerm",
+		"repo": "https://github.com/neapsix/wezterm",
+		"maintainers": [
+			{
+				"name": "neapsix",
+				"url": "https://github.com/neapsix"
+			}
+		],
+		"keywords": ["terminal"],
+		"variants": true
+	},
+	{
 		"name": "Whoogle",
 		"repo": "https://github.com/rose-pine/whoogle",
 		"maintainers": [


### PR DESCRIPTION
Hi there! I've created a Rosé Pine port for the [WezTerm](https://wezfurlong.org/wezterm/) terminal emulator. The theme is at [neapsix/wezterm](https://github.com/neapsix/wezterm). Let me know if there are any changes you'd like to see there or on this PR--thanks!