### PR TITLE
add spotify

### DIFF
--- a/src/lib/data/themes.json
+++ b/src/lib/data/themes.json
@@ -509,6 +509,20 @@
 		"variants": true
 	},
 	{
+		"name": "Spotify",
+		"repo": "https://github.com/nicoleajoy/rose-pine-spotify",
+		"maintainers": [
+			{
+				"name": "Nicole Ajoy",
+				"url": "https://github.com/nicoleajoy"
+			}
+		],
+		"keywords": [
+			"app"
+		],
+		"variants": true
+	},
+	{
 		"name": "st",
 		"repo": "https://github.com/rose-pine/st",
 		"maintainers": [


### PR DESCRIPTION
Hello! I've added Rosé Pine to the [Spicetify themes](https://github.com/spicetify/spicetify-themes) mod for Spotify. Only the **Ziro** theme has it so far (**Dribblish** theme is still on my TODO)! I hope everything else is according to the contributions guidelines. Please let me know if there is anything that needs adjustment.