### PR TITLE
Fix Dutch locale language name

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -6,7 +6,7 @@ export const languages = readable({
 	fr: 'Français',
 	it: 'Italiano',
 	de: 'Deutsch',
-	nl: 'Dutch',
+	nl: 'Nederlands',
 })
 
 export const commandMenuIsOpen = writable(false)


### PR DESCRIPTION
The other translations have their language name in their respective language, this is now true for the Dutch translation as well