### PR TITLE
feat: add contributing guides and palette documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ### Themes
 
-Add a new entry to [`./src/lib/data/themes.json`](https://github.com/rose-pine/rose-pine-site/blob/main/src/lib/data/themes.json)
+Add a new entry to [`./src/themes.json`](https://github.com/rose-pine/rose-pine-site/blob/main/src/themes.json)
 
 ### Translations
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 
 ## Contributing
 
-PR's are welcome and appreciated!
+PRs are welcome and appreciated!
 
 ### Themes
 

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,24 @@
+<p align="center">
+    <img src="https://github.com/rose-pine/rose-pine-theme/raw/main/assets/icon.png" width="80" />
+    <h2 align="center">Rosé Pine Site</h2>
+</p>
+
+<p align="center">All natural pine, faux fur and a bit of soho vibes for the classy minimalist</p>
+
+<p align="center">
+    <a href="https://github.com/rose-pine/rose-pine-theme">
+        <img src="https://img.shields.io/badge/community-rosé%20pine-26233a?labelColor=191724&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjUwIiBoZWlnaHQ9IjIzNyIgdmlld0JveD0iMCAwIDI1MCAyMzciIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xNjEuMjI3IDE2MS4yNTFDMTMyLjE1NCAxNjkuMDQxIDExNC45MDEgMTk4LjkyNCAxMjIuNjkxIDIyNy45OTdDMTIzLjkyNSAyMzIuNjAzIDEyOC42NTkgMjM1LjMzNiAxMzMuMjY0IDIzNC4xMDJMMTg1LjkwNyAyMTkuOTk2QzIxOS41ODUgMjEwLjk3MiAyMzkuNTcgMTc2LjM1NCAyMzAuNTQ2IDE0Mi42NzdMMTYxLjIyNyAxNjEuMjUxWiIgZmlsbD0iIzI0NjI3QiIvPgo8cGF0aCBkPSJNODguMTgzNiAxNTkuOTg4QzExNy4yNTcgMTY3Ljc3OCAxMzQuNTEgMTk3LjY2MiAxMjYuNzIgMjI2LjczNUMxMjUuNDg2IDIzMS4zNCAxMjAuNzUyIDIzNC4wNzMgMTE2LjE0NyAyMzIuODM5TDYzLjUwNDEgMjE4LjczM0MyOS44MjY0IDIwOS43MSA5Ljg0MDk0IDE3NS4wOTIgMTguODY0OSAxNDEuNDE0TDg4LjE4MzYgMTU5Ljk4OFoiIGZpbGw9IiMyNDYyN0IiLz4KPHBhdGggZD0iTTE4Ni44NjcgMTcyLjk4QzE1Mi4wMDIgMTcyLjk4IDEyMy43MzcgMjAxLjI0NSAxMjMuNzM3IDIzNi4xMTFIMTg2Ljg3QzIyMS43MzYgMjM2LjExMSAyNTAgMjA3Ljg0NiAyNTAgMTcyLjk4TDE4Ni44NjcgMTcyLjk4WiIgZmlsbD0iIzMxNzQ4RiIvPgo8cGF0aCBkPSJNNjMuMTMyNyAxNzIuOThDOTcuOTk4NCAxNzIuOTggMTI2LjI2MyAyMDEuMjQ1IDEyNi4yNjMgMjM2LjExMUg2My4xM0MyOC4yNjQyIDIzNi4xMTEgLTEuNTI0MDNlLTA2IDIwNy44NDYgMCAxNzIuOThMNjMuMTMyNyAxNzIuOThaIiBmaWxsPSIjMzE3NDhGIi8+CjxwYXRoIGQ9Ik0xNzEuNzE3IDc1LjEyNjNDMTcxLjcxNyAxMDEuMjc2IDE1MC41MTggMTIyLjQ3NSAxMjQuMzY5IDEyMi40NzVDOTguMjE4OCAxMjIuNDc1IDc3LjAyMDIgMTAxLjI3NiA3Ny4wMjAyIDc1LjEyNjNDNzcuMDIwMiA0OC45NzY0IDk4LjIxODggMjcuNzc3OCAxMjQuMzY5IDI3Ljc3NzhDMTUwLjUxOCAyNy43Nzc4IDE3MS43MTcgNDguOTc2NCAxNzEuNzE3IDc1LjEyNjNaIiBmaWxsPSIjRUJCQ0JBIi8+CjxwYXRoIGQ9Ik0xNDQuMjE3IDg2LjIzNzlDMTYxLjY0OSA1Ni4wNDMyIDE1MS4zMDMgMTcuNDMyOSAxMjEuMTA4IDBMMTA2LjA2IDI2LjA2NDRDODguNjI3IDU2LjI1OSA5OC45NzM2IDk0Ljg2OTQgMTI5LjE2OCAxMTIuMzAyTDE0NC4yMTcgODYuMjM3OVoiIGZpbGw9IiNFQkJDQkEiLz4KPHBhdGggZD0iTTEyNS4yOTkgNjAuOTc4OUMxMTYuMjc1IDI3LjMwMTIgODEuNjU3NSA3LjMxNTY3IDQ3Ljk3OTcgMTYuMzM5Nkw2NC4zMTk3IDc3LjMyMTFDNzMuMzQzNiAxMTAuOTk5IDEwNy45NjEgMTMwLjk4NCAxNDEuNjM5IDEyMS45NkwxMjUuMjk5IDYwLjk3ODlaIiBmaWxsPSIjRUJCQ0JBIi8+CjxwYXRoIGQ9Ik0xMjQuOTI2IDYwLjk3ODlDMTMzLjk1IDI3LjMwMTIgMTY4LjU2NyA3LjMxNTY3IDIwMi4yNDUgMTYuMzM5NkwxODUuOTA1IDc3LjMyMTFDMTc2Ljg4MSAxMTAuOTk5IDE0Mi4yNjMgMTMwLjk4NCAxMDguNTg2IDEyMS45NkwxMjQuOTI2IDYwLjk3ODlaIiBmaWxsPSIjRUJCQ0JBIi8+Cjwvc3ZnPgo=&style=for-the-badge" />
+    </a>
+</p>
+
 ## Contributing
 
-> **Work in progress**
->
-> With the launch of our new website, we are working hard to polish up documentation and guides. Pull requests are welcome 😌
+PR's are welcome and appreciated!
 
 ### Themes
 
-Add a new entry to [`./src/themes.json`](https://github.com/rose-pine/rose-pine-site/blob/main/src/themes.json)
+See our [contributing guide](https://rosepinetheme.com/docs/create) to learn how to add a new theme to the site.
 
 ### Translations
 
-We would love help adding more translations! We'll be adding more information on how to contribute soon, but feel free to duplicate in existing language and go from there :)
+We would love help adding more translations! Check out our [translation guide](https://rosepinetheme.com/docs/translate) for more information.

--- a/scripts/format-themes.js
+++ b/scripts/format-themes.js
@@ -9,7 +9,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const themes = JSON.parse(
-	fs.readFileSync(path.join(process.cwd(), 'src/lib/data/themes.json'), 'utf8')
+	fs.readFileSync(path.join(process.cwd(), 'src/themes.json'), 'utf8')
 )
 
 themes.sort((a, b) => {
@@ -19,6 +19,6 @@ themes.sort((a, b) => {
 })
 
 fs.writeFileSync(
-	path.join(process.cwd(), 'src/lib/data/themes.json'),
+	path.join(process.cwd(), 'src/themes.json'),
 	JSON.stringify(themes)
 )

--- a/src/app.css
+++ b/src/app.css
@@ -22,32 +22,26 @@
 	--love: #b4637a;
 	--love-low: rgba(180, 99, 122, 0.1);
 	--love-med: rgba(180, 99, 122, 0.15);
-	--love-high: rgba(180, 99, 122, 0.2);
 
 	--gold: #ea9d34;
 	--gold-low: rgba(234, 157, 52, 0.1);
 	--gold-med: rgba(234, 157, 52, 0.15);
-	--gold-high: rgba(234, 157, 52, 0.2);
 
 	--rose: #d7827e;
 	--rose-low: rgba(215, 130, 126, 0.1);
 	--rose-med: rgba(215, 130, 126, 0.15);
-	--rose-high: rgba(215, 130, 126, 0.2);
 
 	--pine: #286983;
 	--pine-low: rgba(40, 105, 131, 0.1);
 	--pine-med: rgba(40, 105, 131, 0.2);
-	--pine-high: rgba(40, 105, 131, 0.3);
 
 	--foam: #56949f;
 	--foam-low: rgba(86, 148, 159, 0.1);
 	--foam-med: rgba(86, 148, 159, 0.15);
-	--foam-high: rgba(86, 148, 159, 0.2);
 
 	--iris: #907aa9;
 	--iris-low: rgba(144, 122, 169, 0.1);
 	--iris-med: rgba(144, 122, 169, 0.15);
-	--iris-high: rgba(144, 122, 169, 0.2);
 
 	--highlight-low: rgba(110, 106, 134, 0.05);
 	--highlight-low-blend: rgb(244, 237, 232);
@@ -71,32 +65,26 @@
 		--love: #eb6f92;
 		--love-low: rgba(235, 111, 146, 0.1);
 		--love-med: rgba(235, 111, 146, 0.15);
-		--love-high: rgba(235, 111, 146, 0.2);
 
 		--gold: #f6c177;
 		--gold-low: rgba(246, 193, 119, 0.1);
 		--gold-med: rgba(246, 193, 119, 0.15);
-		--gold-high: rgba(246, 193, 119, 0.2);
 
 		--rose: #ebbcba;
 		--rose-low: rgba(235, 188, 186, 0.1);
 		--rose-med: rgba(235, 188, 186, 0.15);
-		--rose-high: rgba(235, 188, 186, 0.2);
 
 		--pine: #31748f;
 		--pine-low: rgba(49, 116, 143, 0.1);
 		--pine-med: rgba(49, 116, 143, 0.15);
-		--pine-high: rgba(49, 116, 143, 0.2);
 
 		--foam: #9ccfd8;
 		--foam-low: rgba(156, 207, 216, 0.1);
 		--foam-med: rgba(156, 207, 216, 0.15);
-		--foam-high: rgba(156, 207, 216, 0.2);
 
 		--iris: #c4a7e7;
 		--iris-low: rgba(196, 167, 231, 0.1);
 		--iris-med: rgba(196, 167, 231, 0.15);
-		--iris-high: rgba(196, 167, 231, 0.2);
 
 		--highlight-low: rgba(110, 106, 134, 0.1);
 		--highlight-low-blend: rgb(33, 32, 46);

--- a/src/app.css
+++ b/src/app.css
@@ -124,6 +124,13 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+code {
+	padding: 0.125rem 0.25rem;
+	font-size: theme('fontSize.sm');
+	background-color: var(--overlay);
+	border-radius: theme('borderRadius.md');
+}
+
 .animate-enter {
 	opacity: 0;
 	animation: enter 500ms forwards;

--- a/src/lib/components/banner.svelte
+++ b/src/lib/components/banner.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { SvelteComponent } from 'svelte'
+
+	export let icon: SvelteComponent
+	export let scheme: keyof typeof schemes = 'foam'
+
+	const schemes = {
+		love: 'bg-love-low text-love',
+		gold: 'bg-gold-low text-gold',
+		rose: 'bg-rose-low text-rose',
+		pine: 'bg-pine-low text-pine',
+		foam: 'bg-foam-low text-foam',
+		iris: 'bg-iris-low text-iris',
+	}
+</script>
+
+<div class="{schemes[scheme]} rounded-2xl p-6">
+	<div class="flex items-center space-x-3">
+		<div class="shrink-0">
+			<svelte:component this={icon} size={20} />
+		</div>
+		<p class="font-medium"><slot /></p>
+	</div>
+</div>

--- a/src/lib/components/card.svelte
+++ b/src/lib/components/card.svelte
@@ -6,25 +6,25 @@
 
 	const schemes = {
 		default: hoverable
-			? 'bg-surface hover:bg-overlay text-text hover:rounded-2xl'
+			? 'bg-surface hover:bg-overlay text-text hover:rounded-2xl ring-highlight-high'
 			: 'bg-surface text-text',
 		love: hoverable
-			? 'bg-love-low hover:bg-love-med text-love hover:rounded-2xl'
+			? 'bg-love-low hover:bg-love-med text-love hover:rounded-2xl ring-love'
 			: 'bg-love-low text-love',
 		gold: hoverable
-			? 'bg-gold-low hover:bg-gold-med text-gold hover:rounded-2xl'
+			? 'bg-gold-low hover:bg-gold-med text-gold hover:rounded-2xl ring-gold'
 			: 'bg-gold-low text-gold',
 		rose: hoverable
-			? 'bg-rose-low hover:bg-rose-med text-rose hover:rounded-2xl'
+			? 'bg-rose-low hover:bg-rose-med text-rose hover:rounded-2xl ring-rose'
 			: 'bg-rose-low text-rose',
 		pine: hoverable
-			? 'bg-pine-low hover:bg-pine-med text-pine hover:rounded-2xl'
+			? 'bg-pine-low hover:bg-pine-med text-pine hover:rounded-2xl ring-pine'
 			: 'bg-pine-low text-pine',
 		foam: hoverable
-			? 'bg-foam-low hover:bg-foam-med text-foam hover:rounded-2xl'
+			? 'bg-foam-low hover:bg-foam-med text-foam hover:rounded-2xl ring-foam'
 			: 'bg-foam-low text-foam',
 		iris: hoverable
-			? 'bg-iris-low hover:bg-iris-med text-iris hover:rounded-2xl'
+			? 'bg-iris-low hover:bg-iris-med text-iris hover:rounded-2xl ring-iris'
 			: 'bg-iris-low text-iris',
 	}
 </script>
@@ -33,7 +33,7 @@
 	{id}
 	class="{schemes[scheme]} {hasPadding
 		? 'p-6 sm:p-10'
-		: ''} flex h-full w-40 min-w-full flex-col rounded-3xl transition-all duration-200"
+		: ''} flex h-full w-40 min-w-full flex-col rounded-3xl transition-[border-radius,background-color] duration-200 group-focus:ring group-focus:ring-inset"
 >
 	<slot />
 </div>

--- a/src/lib/components/chip.svelte
+++ b/src/lib/components/chip.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	export let hoverable = false
+	export let scheme: keyof typeof schemes = 'default'
+
+	const schemes = {
+		default: hoverable
+			? 'bg-highlight-low hover:bg-highlight-med text-text'
+			: 'bg-highlight-low text-text',
+		love: hoverable
+			? 'bg-love-low hover:bg-love-med text-love'
+			: 'bg-love-low text-love',
+		gold: hoverable
+			? 'bg-gold-low hover:bg-gold-med text-gold'
+			: 'bg-gold-low text-gold',
+		rose: hoverable
+			? 'bg-rose-low hover:bg-rose-med text-rose'
+			: 'bg-rose-low text-rose',
+		pine: hoverable
+			? 'bg-pine-low hover:bg-pine-med text-pine'
+			: 'bg-pine-low text-pine',
+		foam: hoverable
+			? 'bg-foam-low hover:bg-foam-med text-foam'
+			: 'bg-foam-low text-foam',
+		iris: hoverable
+			? 'bg-iris-low hover:bg-iris-med text-iris'
+			: 'bg-iris-low text-iris',
+	}
+</script>
+
+<div
+	class="{schemes[scheme]} rounded-lg px-4 py-1.5 font-mono text-sm font-medium"
+>
+	<slot />
+</div>

--- a/src/lib/components/command-menu.svelte
+++ b/src/lib/components/command-menu.svelte
@@ -16,7 +16,7 @@
 		Search,
 	} from 'tabler-icons-svelte'
 	import { commandMenuIsOpen } from '$lib/store'
-	import rawThemes from '$lib/data/themes.json'
+	import rawThemes from '../../themes.json'
 
 	interface Item {
 		icon: any

--- a/src/lib/components/command-menu.svelte
+++ b/src/lib/components/command-menu.svelte
@@ -14,6 +14,7 @@
 		Notebook,
 		Palette,
 		Search,
+		FileDescription,
 	} from 'tabler-icons-svelte'
 	import { commandMenuIsOpen } from '$lib/store'
 	import rawThemes from '../../themes.json'
@@ -33,6 +34,7 @@
 		{ name: $_('page.home.nav'), url: '/', icon: Home },
 		{ name: $_('page.themes.nav'), url: '/themes', icon: Sailboat },
 		{ name: $_('page.palette.nav'), url: '/palette', icon: Palette },
+		{ name: 'Docs', url: '/docs', icon: FileDescription },
 	]
 
 	const socials: Item[] = [

--- a/src/lib/components/header.svelte
+++ b/src/lib/components/header.svelte
@@ -14,6 +14,7 @@
 	$: menu = [
 		[$_('page.themes.nav'), '/themes'],
 		[$_('page.palette.nav'), '/palette'],
+		['Docs', '/docs'],
 	]
 </script>
 

--- a/src/lib/components/list-item.svelte
+++ b/src/lib/components/list-item.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { getContext } from 'svelte'
+
+	const { shouldShow: shouldShowNumber, get: number } =
+		getContext('list-number')
+</script>
+
+<li
+	class="flex flex-col space-y-3 text-md sm:flex-row sm:items-center sm:space-y-0 sm:space-x-3 {shouldShowNumber
+		? ''
+		: 'ml-[18px] list-item list-disc'}"
+>
+	{#if shouldShowNumber}
+		<span
+			style:color="var(--base)"
+			class="flex h-9 w-6 shrink-0 items-center justify-center rounded-full bg-text text-md font-medium"
+		>
+			{number()}
+		</span>
+	{/if}
+
+	<span><slot /></span>
+</li>

--- a/src/lib/components/list.svelte
+++ b/src/lib/components/list.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { setContext } from 'svelte'
+
+	export let showNumbers = true
+
+	let pos = 0
+	setContext('list-number', {
+		shouldShow: showNumbers,
+		get: () => (pos += 1),
+	})
+</script>
+
+<ul
+	class="flex flex-col space-y-6 leading-relaxed marker:text-subtle sm:space-y-3"
+>
+	<slot />
+</ul>

--- a/src/lib/components/role-card.svelte
+++ b/src/lib/components/role-card.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import palette from '@rose-pine/palette'
+	import Card from '$lib/components/card.svelte'
+	import { toCamelCase } from '$lib/util'
+
+	export let role = 'base'
+
+	const slug = role.toLowerCase().replace(' ', '-').trim()
+	const variants = Object.keys(palette.variants)
+
+	const variantNames = {
+		main: 'Rosé Pine',
+		moon: 'Rosé Pine Moon',
+		dawn: 'Rosé Pine Dawn',
+	}
+</script>
+
+<Card id={slug}>
+	<div class="flex h-full flex-col space-y-6">
+		<div class="flex items-center justify-between">
+			<h3 class="font-display text-xl font-bold tracking-wide">
+				<a href={`#${slug}`} class="capitalize">{role}</a>
+			</h3>
+
+			<div class="inline-flex space-x-2">
+				{#each variants as variant}
+					{@const variantName = variantNames[variant]}
+
+					<div
+						title={`${variantName} ${role}`}
+						class="h-6 w-6 rounded-full border-2 border-highlight-high sm:h-8 sm:w-8"
+						style:background={palette.variants[variant][toCamelCase(role)].hex}
+					/>
+				{/each}
+			</div>
+		</div>
+
+		{#if $$slots.description}
+			<blockquote
+				class="border-l-2 border-highlight-high pl-3 text-md font-medium italic text-subtle"
+			>
+				<slot name="description" />
+			</blockquote>
+		{/if}
+
+		{#if $$slots.list}
+			<ul
+				class="ml-[18px] list-disc text-md leading-relaxed marker:text-subtle"
+			>
+				<slot name="list" />
+			</ul>
+		{/if}
+
+		{#if $$slots.chips}
+			<div class="flex h-full flex-col">
+				<div class="flex-1" />
+
+				<div class="flex items-center space-x-2">
+					<slot name="chips" />
+				</div>
+			</div>
+		{/if}
+	</div>
+</Card>

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,6 +1,14 @@
 import type { Color } from '@rose-pine/palette'
 import { browser } from '$app/env'
 
+export const toCamelCase = (phrase: string) => {
+	return phrase
+		.replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) =>
+			index == 0 ? word.toLowerCase() : word.toUpperCase()
+		)
+		.replace(/\s+/g, '')
+}
+
 export type ColorFormat = 'default' | 'unstyled'
 export const formatColor = (color: Color, format: ColorFormat): Color => {
 	if (format === 'unstyled') {

--- a/src/routes/docs/create.svelte
+++ b/src/routes/docs/create.svelte
@@ -53,7 +53,8 @@
 					</ListItem>
 
 					<ListItem>
-						<strong>Submit your theme</strong> by <Link href="#!"
+						<strong>Submit your theme</strong> by <Link
+							href="https://github.com/rose-pine/rose-pine-theme/issues/new?assignees=&labels=new+theme&template=add-theme.yml&title=New+theme+for+%3Capp%3E"
 							>creating an issue</Link
 						> and we'll invite you to the organization
 					</ListItem>

--- a/src/routes/docs/create.svelte
+++ b/src/routes/docs/create.svelte
@@ -1,0 +1,91 @@
+<script>
+	import { ExternalLink, InfoCircle } from 'tabler-icons-svelte'
+	import Section from '$lib/components/section.svelte'
+	import PageHeading from '$lib/components/page-heading.svelte'
+	import Banner from '$lib/components/banner.svelte'
+	import Button from '$lib/components/button.svelte'
+	import Link from '$lib/components/link.svelte'
+	import ListItem from '$lib/components/list-item.svelte'
+	import List from '$lib/components/list.svelte'
+</script>
+
+<Section>
+	<PageHeading
+		title="Create a theme"
+		description="Contributing guide for designers and creators"
+	>
+		<Button href="https://github.com/rose-pine/rose-pine-template">
+			<span>Project Template</span>
+			<ExternalLink size={16} />
+		</Button>
+	</PageHeading>
+
+	<div class="animate-enter space-y-10" style="--stagger: 2">
+		<Banner icon={InfoCircle}>
+			Work-in-progress document. Translations are not yet available.
+		</Banner>
+
+		<div class="space-y-10">
+			<section
+				class="flex flex-col space-y-6 rounded-3xl bg-surface p-6 sm:p-10"
+			>
+				<h3 class="font-display text-xl font-bold tracking-wide">
+					Official themes
+				</h3>
+
+				<p>
+					Official themes follow our <Link href="/docs/usage">usage guide</Link>
+					and exist in the Rosé Pine organization.
+				</p>
+
+				<List>
+					<ListItem>
+						<strong>Create a repository</strong> based on the Rosé Pine <Link
+							href="https://github.com/rose-pine/rose-pine-template/generate"
+							>template</Link
+						>
+					</ListItem>
+
+					<ListItem>
+						<strong>Build your theme</strong> using the official <Link
+							href="https://github.com/rose-pine/build">build tool</Link
+						> when possible
+					</ListItem>
+
+					<ListItem>
+						<strong>Submit your theme</strong> by <Link href="#!"
+							>creating an issue</Link
+						> and we'll invite you to the organization
+					</ListItem>
+				</List>
+			</section>
+
+			<section
+				class="flex flex-col space-y-6 rounded-3xl bg-surface p-6 sm:p-10"
+			>
+				<h3 class="font-display text-xl font-bold tracking-wide">
+					Community themes
+				</h3>
+
+				<p>
+					Community themes use the Rosé Pine <Link href="/palette">palette</Link
+					> but are not required to strictly follow our <Link href="/docs/usage"
+						>usage guide</Link
+					>.
+				</p>
+
+				<List>
+					<ListItem>
+						<strong>Update your colors</strong> to match our palette
+					</ListItem>
+
+					<ListItem>
+						<strong>Add your theme</strong> to the Rosé Pine site's list of <Link
+							href="#!">themes</Link
+						>
+					</ListItem>
+				</List>
+			</section>
+		</div>
+	</div>
+</Section>

--- a/src/routes/docs/create.svelte
+++ b/src/routes/docs/create.svelte
@@ -80,8 +80,9 @@
 					</ListItem>
 
 					<ListItem>
-						<strong>Add your theme</strong> to the Rosé Pine site's list of <Link
-							href="#!">themes</Link
+						<strong>Add your theme</strong> to the Rosé Pine site's <Link
+							href="https://github.com/rose-pine/rose-pine-site/blob/main/src/themes.json"
+							>list of themes</Link
 						>
 					</ListItem>
 				</List>

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import Section from '$lib/components/section.svelte'
+	import PageHeading from '$lib/components/page-heading.svelte'
+	import Card from '$lib/components/card.svelte'
+</script>
+
+<Section>
+	<PageHeading
+		title="Contributing"
+		description="Usage guides and documentation"
+	/>
+
+	<div class="animate-enter" style="--stagger: 2">
+		<div class="grid gap-6 sm:grid-cols-3">
+			<!-- TODO: Consolidate focus logic between `a` and `Card` -->
+			<a href="/docs/create" class="group focus:outline-none">
+				<Card hoverable hasPadding={false} scheme="foam">
+					<h3
+						class="flex items-center justify-center py-20 px-6 text-center font-display text-2xl tracking-wide"
+					>
+						Create a theme
+					</h3>
+				</Card>
+			</a>
+
+			<a href="/docs/translate" class="group focus:outline-none">
+				<Card hoverable hasPadding={false} scheme="rose">
+					<h3
+						class="flex items-center justify-center py-20 px-6 text-center font-display text-2xl tracking-wide"
+					>
+						Add a translation
+					</h3>
+				</Card>
+			</a>
+
+			<a href="/docs/usage" class="group focus:outline-none">
+				<Card hoverable hasPadding={false} scheme="gold">
+					<h3
+						class="flex items-center justify-center py-20 px-6 text-center font-display text-2xl tracking-wide"
+					>
+						Theme specification
+					</h3>
+				</Card>
+			</a>
+		</div>
+	</div>
+</Section>

--- a/src/routes/docs/translate.svelte
+++ b/src/routes/docs/translate.svelte
@@ -51,7 +51,7 @@
 						<code>src/app.html</code></ListItem
 					>
 					<ListItem
-						><strong>Test your locale</strong> for completeness within
+						><strong>Test your locale</strong> within
 						<code>test/locales.js</code>
 					</ListItem>
 				</List>

--- a/src/routes/docs/translate.svelte
+++ b/src/routes/docs/translate.svelte
@@ -16,7 +16,8 @@
 
 	<div class="animate-enter space-y-10" style="--stagger: 2">
 		<Banner icon={InfoCircle}>
-			Work-in-progress document. Translations are not yet available.
+			We are moving to a different internationalisation library and will update
+			this document once complete.
 		</Banner>
 
 		<div class="space-y-10">
@@ -27,8 +28,32 @@
 					New languages
 				</h3>
 
+				<p>
+					We are working on simplifying these steps. Please open an issue if you
+					get stuck and we'll gladly help out.
+				</p>
+
 				<List>
-					<ListItem>Add a new locale</ListItem>
+					<ListItem
+						><strong>Create a new locale file</strong> inside
+						<code>src/lib/locales/</code></ListItem
+					>
+					<ListItem
+						><strong>Import your locale</strong> inside
+						<code>routes/__layout.svelte</code></ListItem
+					>
+					<ListItem
+						><strong>Declare your locale</strong> in the <code>locales</code>
+						array as well as <code>addMessages(...)</code></ListItem
+					>
+					<ListItem
+						><strong>Add your locale</strong> as a meta tag inside the head of
+						<code>src/app.html</code></ListItem
+					>
+					<ListItem
+						><strong>Test your locale</strong> for completeness within
+						<code>test/locales.js</code>
+					</ListItem>
 				</List>
 			</section>
 
@@ -40,7 +65,16 @@
 				</h3>
 
 				<List>
-					<ListItem>Modify the locale file</ListItem>
+					<ListItem
+						><strong>Ask questions</strong> if anything is unclear. Translations
+						can be complicated!</ListItem
+					>
+					<ListItem
+						><strong>Update translations</strong> within the respsective <Link
+							href="https://github.com/rose-pine/rose-pine-site/tree/main/src/lib/locales"
+							>locale file</Link
+						></ListItem
+					>
 				</List>
 			</section>
 		</div>

--- a/src/routes/docs/translate.svelte
+++ b/src/routes/docs/translate.svelte
@@ -1,0 +1,48 @@
+<script>
+	import { InfoCircle } from 'tabler-icons-svelte'
+	import Section from '$lib/components/section.svelte'
+	import PageHeading from '$lib/components/page-heading.svelte'
+	import Banner from '$lib/components/banner.svelte'
+	import Link from '$lib/components/link.svelte'
+	import ListItem from '$lib/components/list-item.svelte'
+	import List from '$lib/components/list.svelte'
+</script>
+
+<Section>
+	<PageHeading
+		title="Add a translation"
+		description="Contributing guide for translators"
+	/>
+
+	<div class="animate-enter space-y-10" style="--stagger: 2">
+		<Banner icon={InfoCircle}>
+			Work-in-progress document. Translations are not yet available.
+		</Banner>
+
+		<div class="space-y-10">
+			<section
+				class="flex flex-col space-y-6 rounded-3xl bg-surface p-6 sm:p-10"
+			>
+				<h3 class="font-display text-xl font-bold tracking-wide">
+					New languages
+				</h3>
+
+				<List>
+					<ListItem>Add a new locale</ListItem>
+				</List>
+			</section>
+
+			<section
+				class="flex flex-col space-y-6 rounded-3xl bg-surface p-6 sm:p-10"
+			>
+				<h3 class="font-display text-xl font-bold tracking-wide">
+					Existing languages
+				</h3>
+
+				<List>
+					<ListItem>Modify the locale file</ListItem>
+				</List>
+			</section>
+		</div>
+	</div>
+</Section>

--- a/src/routes/docs/translate.svelte
+++ b/src/routes/docs/translate.svelte
@@ -70,7 +70,7 @@
 						can be complicated!</ListItem
 					>
 					<ListItem
-						><strong>Update translations</strong> within the respsective <Link
+						><strong>Update translations</strong> within the respective <Link
 							href="https://github.com/rose-pine/rose-pine-site/tree/main/src/lib/locales"
 							>locale file</Link
 						></ListItem

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -113,8 +113,8 @@
 				<svelte:fragment slot="description">Be kind; love all</svelte:fragment>
 
 				<svelte:fragment slot="list">
-					<li>Deleted files in Git</li>
 					<li>Diagnostic errors</li>
+					<li>Deleted files in Git</li>
 					<li>Terminal red, bright red</li>
 				</svelte:fragment>
 

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -50,6 +50,7 @@
 					<li>Active backgrounds, e.g. tabs, list items</li>
 					<li>Inputs, e.g. text search, checkboxes</li>
 					<li>Hover selections</li>
+					<li>Terminal black</li>
 				</svelte:fragment>
 			</RoleCard>
 
@@ -60,6 +61,7 @@
 
 				<svelte:fragment slot="list">
 					<li>Ignored content, e.g. filenames ignored by Git</li>
+					<li>Terminal bright black</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">
@@ -99,6 +101,7 @@
 							>highlight med</a
 						> background
 					</li>
+					<li>Terminal white, bright white</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">
@@ -112,6 +115,7 @@
 				<svelte:fragment slot="list">
 					<li>Deleted files in Git</li>
 					<li>Diagnostic errors</li>
+					<li>Terminal red, bright red</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">
@@ -125,6 +129,7 @@
 				>
 				<svelte:fragment slot="list">
 					<li>Diagnostic warnings</li>
+					<li>Terminal yellow, bright yellow</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">
@@ -141,6 +146,7 @@
 						Matching search background paired with <a href="#base">base</a> foreground
 					</li>
 					<li>Modified files in Git</li>
+					<li>Terminal cyan, bright cyan</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">
@@ -154,6 +160,7 @@
 				>
 				<svelte:fragment slot="list">
 					<li>Renamed files in Git</li>
+					<li>Terminal green, bright green</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">
@@ -166,6 +173,7 @@
 				<svelte:fragment slot="list">
 					<li>Additions in Git</li>
 					<li>Diagnostic information</li>
+					<li>Terminal blue, bright blue</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">
@@ -182,6 +190,7 @@
 					<li>Merged and staged changes in Git</li>
 					<li>Diagnostic hints</li>
 					<li>Inline links</li>
+					<li>Terminal magenta, bright magenta</li>
 				</svelte:fragment>
 
 				<svelte:fragment slot="chips">

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -187,9 +187,9 @@
 					>Smells of groundedness</svelte:fragment
 				>
 				<svelte:fragment slot="list">
-					<li>Merged and staged changes in Git</li>
 					<li>Diagnostic hints</li>
 					<li>Inline links</li>
+					<li>Merged and staged changes in Git</li>
 					<li>Terminal magenta, bright magenta</li>
 				</svelte:fragment>
 

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -171,8 +171,8 @@
 			<RoleCard role="foam">
 				<svelte:fragment slot="description">Summer bubbles</svelte:fragment>
 				<svelte:fragment slot="list">
-					<li>Additions in Git</li>
 					<li>Diagnostic information</li>
+					<li>Additions in Git</li>
 					<li>Terminal blue, bright blue</li>
 				</svelte:fragment>
 

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -30,7 +30,7 @@
 
 			<RoleCard role="surface">
 				<svelte:fragment slot="description"
-					>Low contrast background atop <a href="#base">base</a
+					>Secondary background atop <a href="#base">base</a
 					></svelte:fragment
 				>
 

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -169,7 +169,7 @@
 			</RoleCard>
 
 			<RoleCard role="foam">
-				<svelte:fragment slot="description">Summer bubbles</svelte:fragment>
+				<svelte:fragment slot="description">Saltwater tidepools</svelte:fragment>
 				<svelte:fragment slot="list">
 					<li>Diagnostic information</li>
 					<li>Additions in Git</li>

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -125,7 +125,7 @@
 
 			<RoleCard role="gold">
 				<svelte:fragment slot="description"
-					>Wealth is not gold, but the feeling of</svelte:fragment
+					>Lemon tea on a summer morning</svelte:fragment
 				>
 				<svelte:fragment slot="list">
 					<li>Diagnostic warnings</li>

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -35,7 +35,7 @@
 				>
 
 				<svelte:fragment slot="list">
-					<li>Secondary panels, e.g. editor terminals</li>
+					<li>Accessory panels, e.g. editor terminals</li>
 					<li>Inputs, e.g. text search, checkboxes</li>
 				</svelte:fragment>
 			</RoleCard>

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -1,0 +1,225 @@
+<script>
+	import { InfoCircle } from 'tabler-icons-svelte'
+	import Section from '$lib/components/section.svelte'
+	import PageHeading from '$lib/components/page-heading.svelte'
+	import Banner from '$lib/components/banner.svelte'
+	import Chip from '$lib/components/chip.svelte'
+	import RoleCard from '$lib/components/role-card.svelte'
+</script>
+
+<Section>
+	<PageHeading
+		title="Theme specification"
+		description="Palette usage and roles"
+	/>
+
+	<div class="animate-enter space-y-6" style="--stagger: 2">
+		<Banner icon={InfoCircle}>
+			Work-in-progress document. Translations are not yet available.
+		</Banner>
+
+		<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+			<RoleCard role="base">
+				<svelte:fragment slot="description">Primary background</svelte:fragment>
+
+				<svelte:fragment slot="list">
+					<li>General backgrounds, e.g. windows, tabs</li>
+					<li>Extended panels, e.g. sidebars</li>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="surface">
+				<svelte:fragment slot="description"
+					>Low contrast background atop <a href="#base">base</a
+					></svelte:fragment
+				>
+
+				<svelte:fragment slot="list">
+					<li>Secondary panels, e.g. editor terminals</li>
+					<li>Inputs, e.g. text search, checkboxes</li>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="overlay">
+				<svelte:fragment slot="description"
+					>Medium contrast background atop <a href="#surface">surface</a
+					></svelte:fragment
+				>
+
+				<svelte:fragment slot="list">
+					<li>Active backgrounds, e.g. tabs, list items</li>
+					<li>Inputs, e.g. text search, checkboxes</li>
+					<li>Hover selections</li>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="muted">
+				<svelte:fragment slot="description"
+					>Low contrast foreground</svelte:fragment
+				>
+
+				<svelte:fragment slot="list">
+					<li>Ignored content, e.g. filenames ignored by Git</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-muted">Comments</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="subtle">
+				<svelte:fragment slot="description"
+					>Medium contrast foreground</svelte:fragment
+				>
+
+				<svelte:fragment slot="list">
+					<li>Inactive foregrounds, e.g. tabs, list items</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-subtle">Operators</span></Chip>
+					<Chip><span class="text-subtle">Punctuation</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="text">
+				<svelte:fragment slot="description"
+					>High contrast foreground</svelte:fragment
+				>
+
+				<svelte:fragment slot="list">
+					<li>Active foregrounds, e.g. tabs, list items</li>
+					<li>
+						Cursor foreground paired with <a href="#highlight-high"
+							>highlight high</a
+						> background
+					</li>
+					<li>
+						Selection foreground paired with <a href="#highlight-med"
+							>highlight med</a
+						> background
+					</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-text">Variables</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="love">
+				<svelte:fragment slot="description">Be kind; love all</svelte:fragment>
+
+				<svelte:fragment slot="list">
+					<li>Deleted files in Git</li>
+					<li>Diagnostic errors</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-love">Built-ins</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="gold">
+				<svelte:fragment slot="description"
+					>Wealth is not gold, but the feeling of</svelte:fragment
+				>
+				<svelte:fragment slot="list">
+					<li>Diagnostic warnings</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-gold">Strings</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="rose">
+				<svelte:fragment slot="description"
+					>A beautiful yet cautious blossom</svelte:fragment
+				>
+				<svelte:fragment slot="list">
+					<li>
+						Matching search background paired with <a href="#base">base</a> foreground
+					</li>
+					<li>Modified files in Git</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-rose">Booleans</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="pine">
+				<svelte:fragment slot="description"
+					>Fresh winter greenery</svelte:fragment
+				>
+				<svelte:fragment slot="list">
+					<li>Renamed files in Git</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-pine">Functions</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="foam">
+				<svelte:fragment slot="description">Summer bubbles</svelte:fragment>
+				<svelte:fragment slot="list">
+					<li>Additions in Git</li>
+					<li>Diagnostic information</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-foam">Keys</span></Chip>
+					<Chip><span class="text-foam">Tags</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="iris">
+				<svelte:fragment slot="description"
+					>Smells of groundedness</svelte:fragment
+				>
+				<svelte:fragment slot="list">
+					<li>Merged and staged changes in Git</li>
+					<li>Diagnostic hints</li>
+					<li>Inline links</li>
+				</svelte:fragment>
+
+				<svelte:fragment slot="chips">
+					<Chip><span class="text-iris">Parameters</span></Chip>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="highlight low">
+				<svelte:fragment slot="description"
+					>Low contrast highlight</svelte:fragment
+				>
+				<svelte:fragment slot="list">
+					<li>Cursorline background</li>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="highlight med">
+				<svelte:fragment slot="description"
+					>Medium contrast highlight</svelte:fragment
+				>
+				<svelte:fragment slot="list">
+					<li>
+						Selection background paired with <a href="#text">text</a> foreground
+					</li>
+				</svelte:fragment>
+			</RoleCard>
+
+			<RoleCard role="highlight high">
+				<svelte:fragment slot="description"
+					>High contrast highlight</svelte:fragment
+				>
+				<svelte:fragment slot="list">
+					<li>Borders / visual dividers</li>
+					<li>
+						Cursor background paired with <a href="#text">text</a> foreground
+					</li>
+				</svelte:fragment>
+			</RoleCard>
+		</div>
+	</div>
+</Section>

--- a/src/routes/docs/usage.svelte
+++ b/src/routes/docs/usage.svelte
@@ -42,7 +42,7 @@
 
 			<RoleCard role="overlay">
 				<svelte:fragment slot="description"
-					>Medium contrast background atop <a href="#surface">surface</a
+					>Tertiary background atop <a href="#surface">surface</a
 					></svelte:fragment
 				>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -4,8 +4,8 @@
 	import Button from '$lib/components/button.svelte'
 	import Editor from '$lib/components/editor/index.svelte'
 	import { Grain, Seeding, SquaresFilled } from 'tabler-icons-svelte'
-	import themes from '$lib/data/themes.json'
 	import PageHeading from '$lib/components/page-heading.svelte'
+	import themes from '../themes.json'
 </script>
 
 <PageHeading

--- a/src/routes/themes.svelte
+++ b/src/routes/themes.svelte
@@ -4,8 +4,8 @@
 	import { Notebook, Sun, Moon, Palette } from 'tabler-icons-svelte'
 	import Section from '$lib/components/section.svelte'
 	import Search from '$lib/components/search.svelte'
-	import themes from '$lib/data/themes.json'
 	import PageHeading from '$lib/components/page-heading.svelte'
+	import themes from '../themes.json'
 
 	let query = ''
 	$: filteredThemes = themes.filter((theme) =>

--- a/src/themes.json
+++ b/src/themes.json
@@ -219,15 +219,11 @@
 		"keywords": ["web"],
 		"variants": false
 	},
-		{
+	{
 		"name": "GitKraken",
 		"repo": "https://github.com/rose-pine/gitkraken",
 		"maintainers": [
-			{
-				"name": "Diorcula",
-				"url": "https://github.com/diorcula"
-			}
-			
+			{ "name": "Diorcula", "url": "https://github.com/diorcula" }
 		],
 		"keywords": ["productivity"],
 		"variants": true
@@ -538,14 +534,9 @@
 		"name": "Spotify",
 		"repo": "https://github.com/nicoleajoy/rose-pine-spotify",
 		"maintainers": [
-			{
-				"name": "Nicole Ajoy",
-				"url": "https://github.com/nicoleajoy"
-			}
+			{ "name": "Nicole Ajoy", "url": "https://github.com/nicoleajoy" }
 		],
-		"keywords": [
-			"app"
-		],
+		"keywords": ["app"],
 		"variants": true
 	},
 	{

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -25,37 +25,31 @@ module.exports = {
 					DEFAULT: 'var(--love)',
 					low: 'var(--love-low)',
 					med: 'var(--love-med)',
-					high: 'var(--love-high)',
 				},
 				gold: {
 					DEFAULT: 'var(--gold)',
 					low: 'var(--gold-low)',
 					med: 'var(--gold-med)',
-					high: 'var(--gold-high)',
 				},
 				rose: {
 					DEFAULT: 'var(--rose)',
 					low: 'var(--rose-low)',
 					med: 'var(--rose-med)',
-					high: 'var(--rose-high)',
 				},
 				pine: {
 					DEFAULT: 'var(--pine)',
 					low: 'var(--pine-low)',
 					med: 'var(--pine-med)',
-					high: 'var(--pine-high)',
 				},
 				foam: {
 					DEFAULT: 'var(--foam)',
 					low: 'var(--foam-low)',
 					med: 'var(--foam-med)',
-					high: 'var(--foam-high)',
 				},
 				iris: {
 					DEFAULT: 'var(--iris)',
 					low: 'var(--iris-low)',
 					med: 'var(--iris-med)',
-					high: 'var(--iris-high)',
 				},
 				highlight: {
 					low: 'var(--highlight-low)',


### PR DESCRIPTION
Adds the following pages:

- [x] Documentation categories [/docs](https://deploy-preview-64--rosepinetheme.netlify.app/docs)
- [x] Palette usage [/docs/usage](https://deploy-preview-64--rosepinetheme.netlify.app/docs/usage)
	- [x] Add terminal color relation, e.g. magenta → iris
- [x] Create a theme [/docs/create](https://deploy-preview-64--rosepinetheme.netlify.app/docs/create)
- [x] Add a translation [/docs/translate](https://deploy-preview-64--rosepinetheme.netlify.app/docs/translate)

Misc todo:

- [ ] Use consistent semi-transparent accents, e.g. check against our VSCode theme

Closes #19
Closes #47 