### PR TITLE
Add GDevelop to Themes List (See Issue #70)

### DIFF
--- a/src/themes.json
+++ b/src/themes.json
@@ -226,6 +226,13 @@
 		"variants": true
 	},
 	{
+		"name": "GDevelop",
+		"repo": "https://github.com/rose-pine/GDevelop",
+		"maintainers": [{ "name": "Ehan", "url": "https://github.com/EhanAhamed" }],
+		"keywords": ["app", "editor"],
+		"variants": false
+	},
+	{
 		"name": "GitHub Readme Stats",
 		"repo": "https://github.com/rose-pine/github-readme-stats",
 		"maintainers": [


### PR DESCRIPTION
As the title says, see issue #70 for more info.

Also see [this pull request](https://github.com/4ian/GDevelop/pull/4079) in GDevelop's repo if you want I guess?

Goodday/afternoon/night