### PR TITLE
Another round of command palette improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"@rose-pine/palette": "^3.0.1",
 		"has-match": "^1.0.3",
+		"soggy": "^0.1.0",
 		"svelte-i18n": "^3.4.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"dependencies": {
 		"@rose-pine/palette": "^3.0.1",
 		"has-match": "^1.0.3",
-		"soggy": "^0.1.0",
+		"soggy": "^0.1.18",
 		"svelte-i18n": "^3.4.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   postcss: ^8.4.16
   prettier: ^2.7.1
   prettier-plugin-tailwindcss: ^0.1.13
+  soggy: ^0.1.0
   svelte: ^3.49.0
   svelte-check: ^2.8.1
   svelte-i18n: ^3.4.0
@@ -23,6 +24,7 @@ specifiers:
 dependencies:
   '@rose-pine/palette': 3.0.1
   has-match: 1.0.3
+  soggy: 0.1.0
   svelte-i18n: 3.4.0_svelte@3.49.0
 
 devDependencies:
@@ -1775,6 +1777,12 @@ packages:
       ansi-styles: 6.1.0
       is-fullwidth-code-point: 4.0.0
     dev: true
+
+  /soggy/0.1.0:
+    resolution: {integrity: sha512-R7lMwAY8ToiPf78CkGakB/g+K3PyjpB3nEBscS98rVfWid0B6wpe+tOmInnLcqdJomuvA+PVDMp4FUsloQSzDA==}
+    dependencies:
+      has-match: 1.0.3
+    dev: false
 
   /sorcery/0.10.0:
     resolution: {integrity: sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ specifiers:
   postcss: ^8.4.16
   prettier: ^2.7.1
   prettier-plugin-tailwindcss: ^0.1.13
-  soggy: ^0.1.0
+  soggy: ^0.1.18
   svelte: ^3.49.0
   svelte-check: ^2.8.1
   svelte-i18n: ^3.4.0
@@ -24,7 +24,7 @@ specifiers:
 dependencies:
   '@rose-pine/palette': 3.0.1
   has-match: 1.0.3
-  soggy: 0.1.0
+  soggy: 0.1.18
   svelte-i18n: 3.4.0_svelte@3.49.0
 
 devDependencies:
@@ -1778,8 +1778,8 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
-  /soggy/0.1.0:
-    resolution: {integrity: sha512-R7lMwAY8ToiPf78CkGakB/g+K3PyjpB3nEBscS98rVfWid0B6wpe+tOmInnLcqdJomuvA+PVDMp4FUsloQSzDA==}
+  /soggy/0.1.18:
+    resolution: {integrity: sha512-vzztfBCIVB8LuQ2p4xsqErqlHHRrzJcVEI0NTuyWB9/aa7X7F5bAaTXRQ7mqAmMcvh33hHDdM9hxA0+M42l08g==}
     dependencies:
       has-match: 1.0.3
     dev: false


### PR DESCRIPTION
## Use [soggy](https://www.npmjs.com/package/soggy)

Soggy handles the filtering and keyboard navigation. This is a new library that still has bugs, but breaking out the logic is desirable. PRs are more than welcome over there!

## Make faster

Perhaps soggy's filtering logic could be improved or the sheer amount of loops and reactivity could be reduced when creating our command list. I've experimented with virtual lists with no luck, mostly because our data is nested in groups.

## Make better

As mentioned above, soggy has bugs. The first item is not always selected and the selected item does not properly scroll into view.


Open to suggestions and feedback :)