### PR TITLE
Fix broken template repo links

### DIFF
--- a/src/content/guides/en/create-a-theme.md
+++ b/src/content/guides/en/create-a-theme.md
@@ -9,9 +9,9 @@ priority: 99
 We love and welcome themes from everyone. To add your creation to the Rosé
 Pine organisation, we ask that your theme follows our [palette
 specification](/palette) and your repository resembles our
-[template](https://github.com/rose-pine/template).
+[template](https://github.com/rose-pine/rose-pine-template).
 
-1. Use the [Rosé Pine template](https://github.com/rose-pine/template) as a
+1. Use the [Rosé Pine template](https://github.com/rose-pine/rose-pine-template) as a
    base for your new repository.
 2. Build your theme with the official [build
    tool](https://github.com/rose-pine/build) when possible to include all

--- a/src/content/guides/id/create-a-theme.md
+++ b/src/content/guides/id/create-a-theme.md
@@ -9,9 +9,9 @@ priority: 99
 Kami menyukai dan menyambut baik tema dari semua orang. Untuk menambahkan
 kreasi Anda ke organisasi Rosé Pine, kami meminta agar tema Anda mengikuti
 [spesifikasi palet](/id/palette) kami dan repositori Anda menyesuaikan
-[template](https://github.com/rose-pine/template) kami.
+[template](https://github.com/rose-pine/rose-pine-template) kami.
 
-1. Gunakan [template Rosé Pine](https://github.com/rose-pine/template) sebagai
+1. Gunakan [template Rosé Pine](https://github.com/rose-pine/rose-pine-template) sebagai
    dasar untuk repositori baru Anda.
 2. Buat tema Anda dengan [build tool](https://github.com/rose-pine/build) resmi
    jika memungkinkan untuk menyertakan ketiga varian.


### PR DESCRIPTION
The "Create a theme" page links to `rose-pine/template`, which doesn't exist. It should point to `rose-pine/rose-pine-template`