### PR TITLE
add view transitions

### DIFF
--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -1,6 +1,7 @@
 ---
 import i18next, { t } from "i18next";
 import { localizePath, localizeUrl } from "astro-i18next";
+import { ViewTransitions } from "astro:transitions";
 import { roles, roleKeys } from "@rose-pine/palette";
 import Banner from "$components/banner.svelte";
 import Header from "$components/header.astro";
@@ -107,6 +108,7 @@ const groups = [
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="description" content={description} />
 		<meta property="og:image" content="/assets/opengraph-image.jpg" />
+		<ViewTransitions />
 		<title>{title}</title>
 
 		{


### PR DESCRIPTION
* Allows unchanged content to skip re-render on navigation. See https://docs.astro.build/en/guides/view-transitions/
* Uses Astro's standard "fade" animation to transition changing content. It's possible to override this setting with another animation style. See https://docs.astro.build/en/guides/view-transitions/#built-in-animation-directives
* Possible improvement: navigating between "swatches" / "ingredients" on the palette page while scrolled down scrolls the page up, preventing natural-feeling animation. Couldn't find a way to change this behavior but would be a good opportunity for further improvement.