### PR TITLE
Add dunst theme

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -61,6 +61,15 @@
 		"has_variants": true
 	},
 	{
+		"name": "dunst",
+		"url": "https://github.com/d2718nis/rose-pine-dunst",
+		"tags": ["app"],
+		"authors": [
+			{ "name": "d2718nis", "url": "https://github.com/d2718nis" }
+		],
+		"has_variants": true
+	},
+	{
 		"name": "Emacs",
 		"url": "https://github.com/konrad1977/pinerose-emacs",
 		"tags": ["app", "terminal", "editor"],

--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -328,15 +328,15 @@
 		],
 		"has_variants": true
 	},
-    {
-        "name": "swaylock",
-        "url": "https://github.com/d2718nis/rose-pine-swaylock",
-        "tags": ["app"],
-        "authors": [
-            { "name": "d2718nis", "url": "https://github.com/d2718nis" }
-        ],
-        "has_variants": true
-    },
+	{
+		"name": "swaylock",
+		"url": "https://github.com/d2718nis/rose-pine-swaylock",
+		"tags": ["app"],
+		"authors": [
+			{ "name": "d2718nis", "url": "https://github.com/d2718nis" }
+		],
+		"has_variants": true
+	},
 	{
 		"name": "Telegram",
 		"url": "https://github.com/asdreemurr844/rose-pine-telegram-ios",


### PR DESCRIPTION
Created a new Rosé Pine inspired [theme](https://github.com/d2718nis/rose-pine-dunst) for [dunst](https://github.com/dunst-project/dunst) notifications manager daemon. Also fixed formatting for my previous theme for swaylock: replaced whitespaces with tabs.