### PR TITLE
Add Turkish Translation

### DIFF
--- a/src/components/language-select.svelte
+++ b/src/components/language-select.svelte
@@ -18,6 +18,7 @@
 		it: "Italiano",
 		nl: "Nederlands",
 		sv: "Svenska",
+                tr: "Türkçe",
 		"zh-CN": "简体中文",
 	};
 </script>

--- a/src/content/guides/tr/add-a-translation.md
+++ b/src/content/guides/tr/add-a-translation.md
@@ -1,0 +1,31 @@
+---
+title: Bir çeviri ekle
+description: Çevirmenler için katkıda bulunma rehberi.
+priority: 98
+---
+
+## Geliştirme ortamınızı ayarlayın
+
+> Herhangi bir değişikliği doğrudan GitHub'da yapmaktan çekinmeyin
+
+1. [Rosé Pine web sitesini](https://github.com/rose-pine/rose-pine-site) forklayın ve klonlayın.
+2. [node'u](https://nodejs.org) ve [pnpm'i](https://pnpm.io/installation) yükleyin.
+3. Web sitesinin dizinindeyken bağımlılıkları yükleyin ve
+   yerel geliştirme sunucusunu başlatın:
+   ```sh
+   pnpm install && pnpm dev
+   ```
+4. Değişiklikleri gerçek zamanda görüntülemek için 
+   http://localhost:3000 adresine gidin.
+
+### Dökümantasyon çevirin
+
+1. `src/content/{locale}/` dizininde yeni bir sayfa oluşturun
+2. İngilizce eşdeğer sayfayı veya rahat olduğunuz başka bir
+   yerel ayarı referans alın, örneğin `src/content/en/create-a-theme.md`
+
+### Sayfa snippet'lerini çevirin
+
+1. `src/locales/{locale}.json` dizininde yeni bir yerel ayar dosyası oluşturun
+2. İngilizce eşdeğer şemayı veya rahat olduğunuz başka bir 
+yerel ayarı referans alın, örneğin `src/locales/en.json`

--- a/src/content/guides/tr/create-a-theme.md
+++ b/src/content/guides/tr/create-a-theme.md
@@ -1,0 +1,25 @@
+---
+title: Bir tema oluştur
+description: Tasarımcılar için katkıda bulunma rehberi.
+priority: 99
+---
+
+## Resmî depolar
+
+Herkesten gelen temaları seviyor ve memnuniyetle karşılıyoruz. 
+Eserinizi Rosé Pine organizasyonuna eklemek için, temanızın palet spesifikasyonumuza uymasını 
+ve deponuzun [şablonumuza](https://github.com/rose-pine/rose-pine-template) benzemesini rica ediyoruz.
+
+1. Yeni deponuz için temel olarak 
+   [Rosé Pine şablonu](https://github.com/rose-pine/rose-pine-template) kullanın
+2. Mümkün olduğunda temanızı resmi [derleme aracı](https://github.com/rose-pine/build) ile oluşturarak üç varyantı da ekleyin.
+3. Temanızı [GitHub üzerinden bir sorun (issue) oluşturarak] gönderin ve sizi organizasyona davet ederiz.
+
+## Topluluk depoları
+
+Resmî temalar [Rosé Pine paletini](/palette/ingredients) takip ederken, 
+topluluk temalarının önerilen renk kullanımlarımızı takip etmesi gerekmez.
+
+1. Renklerinizi [palet](/palette/ingredients) ile eşleşecek şekilde güncelleyin, 
+   isteğe bağlı olarak [derleme aracını](https://github.com/rose-pine/build) kullanın.
+2. Temanızı Rosé Pine web sitesinde yer alan [topluluk listesine](https://github.com/rose-pine/rose-pine-site/blob/main/src/data/community-repos.json) ekleyin.

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -36,7 +36,7 @@
 	"palette": {
 		"title": "Palet",
 		"description": "Seçilmiş renkler, sonsuz eserler.",
-		"tagline": "{{numberOfVariants}} varyant ve {{numberOfColors}} renk",
+		"tagline": "{{numberOfVariants}} varyant & {{numberOfColors}} renk",
 		"tabs": {
 			"swatches": "Renk örnekleri",
 			"ingredients": "Malzemeler"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -30,7 +30,7 @@
 	"themes": {
 		"title": "Temalar",
 		"description": "El yapımı kişiselleştirme koleksiyonu.",
-		"tagline": "{{numberOfPorts}} uyarlama & {{numberOfAuthors}} yazarlar",
+		"tagline": "{{numberOfPorts}} uyarlama & {{numberOfAuthors}} yazar",
 		"search_label": "Temalar arayın..."
 	},
 	"palette": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1,0 +1,70 @@
+{
+	"navigation": {
+		"home": "Ana sayfa",
+		"themes": "Temalar",
+		"palette": "Palet",
+		"ingredients": "Malzemeler",
+		"resources": "Kaynaklar",
+		"languages": "Diller"
+	},
+	"home": {
+		"title": "Güzel bir şey",
+		"description": "Şık minimalistler için tamamen doğal çam, suni kürk ve biraz da soho havası.",
+		"discover_button": "Keşfet",
+		"feature_card_1": {
+			"title": "İnce estetik",
+			"description": "Yumuşak ve rahat paletimizle gözlerinize hak ettiği molayı verin.",
+			"link": "Paletimiz"
+		},
+		"feature_card_2": {
+			"title": "Adaptif ruh halleri",
+			"description": "Gününüzün her saati için özel olarak hazırlanmış varyantların keyfini çıkarın.",
+			"link": "Temalar keşfet"
+		},
+		"feature_card_3": {
+			"title": "Topluluk odaklı",
+			"description": "Rosé Pine'ın favori uygulamalarınızdan {{numberOfPorts}} fazlasına getirilmesine yardımcı oldunuz.",
+			"link": "Dahil olun"
+		}
+	},
+	"themes": {
+		"title": "Temalar",
+		"description": "El yapımı kişiselleştirme koleksiyonu.",
+		"tagline": "{{numberOfPorts}} uyarlama & {{numberOfAuthors}} yazarlar",
+		"search_label": "Temalar arayın..."
+	},
+	"palette": {
+		"title": "Palet",
+		"description": "Seçilmiş renkler, sonsuz eserler.",
+		"tagline": "{{numberOfVariants}} varyant ve {{numberOfColors}} renk",
+		"tabs": {
+			"swatches": "Renk örnekleri",
+			"ingredients": "Malzemeler"
+		}
+	},
+	"ingredients": {
+		"title": "Malzemeler",
+		"description": "Biçimlendirilmiş renk değerleri.",
+		"decorations_label": "Dekorasyonlar"
+	},
+	"resources": {
+		"title": "Kaynaklar",
+		"description": "Katkıda bulunanlar için hafif bir araç kutusu.",
+		"help_link": "Discord sunucumuzdan yardım alın"
+	},
+	"global_search": {
+		"trigger": "Ara",
+		"placeholder": "Sayfalar, temalar ve paletler arayın...",
+		"empty_text": "Herhangi bir sonuç bulunamadı.",
+		"empty_result_1": "Tüm temaları keşfedin",
+		"empty_result_2": "Rosé Pine'a katkıda bulunun",
+		"heading_pages": "Sayfalar",
+		"heading_themes": "Temalar",
+		"heading_featured_themes": "Öne çıkan temalar",
+		"heading_palette": "Palet",
+		"heading_community": "Topluluk"
+	},
+	"shared": {
+		"read_more": "Daha fazla bilgi edinin"
+	}
+}

--- a/src/pages/tr/index.astro
+++ b/src/pages/tr/index.astro
@@ -1,0 +1,126 @@
+---
+import { t, changeLanguage } from "i18next";
+import { localizePath } from "astro-i18next";
+import { IconHeartHandshake, IconSeeding, IconShadow } from "$components/icons";
+import Layout from "$layouts/base.astro";
+import EditorFrame from "$components/editor-frame.svelte";
+import Card from "$components/card.svelte";
+import { themes } from "$data/themes";
+
+changeLanguage("tr");
+---
+
+<Layout title={t("home.title")} description={t("home.description")}>
+	<section
+		class="grid min-h-content items-center gap-20 lg:grid-cols-[1fr,minmax(0,1fr)]"
+	>
+		<div class="space-y-6 text-center lg:space-y-10 lg:text-left">
+			<h1
+				class="animate-enter font-display text-5xl font-bold tracking-tight lg:text-8xl"
+			>
+				{t("home.title")}
+			</h1>
+
+			<p
+				class="animate-enter mx-auto max-w-sm text-lg text-subtle lg:mx-0 lg:max-w-md lg:text-xl"
+				style="--stagger: 1"
+			>
+				{t("home.description")}
+			</p>
+
+			<div>
+				<a
+					href={localizePath("/themes")}
+					class="animate-enter inline-flex h-12 items-center rounded-full bg-muted/10 px-6 font-medium transition hover:bg-muted/20 focus:outline-none focus:ring"
+					style="--stagger: 2">{t("home.discover_button")}&nbsp;&rarr;</a
+				>
+			</div>
+		</div>
+
+		<div class="animate-enter overflow-hidden" style="--stagger: 1">
+			<EditorFrame />
+		</div>
+	</section>
+
+	<div class="h-20"></div>
+
+	<section
+		class="mx-auto grid max-w-lg grid-cols-1 gap-10 md:max-w-full md:grid-cols-3 md:gap-6"
+	>
+		<Card
+			size="lg"
+			href={localizePath("/palette")}
+			linkText={t("home.feature_card_1.link")}
+		>
+			<div
+				class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-foam to-pine text-surface"
+			>
+				<IconSeeding size={28} stroke={1.5} />
+			</div>
+
+			<div class="h-6"></div>
+
+			<h2 class="text-lg font-bold leading-none tracking-tight">
+				{t("home.feature_card_1.title")}
+			</h2>
+
+			<div class="h-3"></div>
+
+			<p>
+				{t("home.feature_card_1.description")}
+			</p>
+		</Card>
+
+		<Card
+			size="lg"
+			href={localizePath("/themes")}
+			linkText={t("home.feature_card_2.link")}
+		>
+			<div
+				class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-iris to-gold text-surface"
+			>
+				<IconShadow size={28} stroke={1.5} />
+			</div>
+
+			<div class="h-6"></div>
+
+			<h2 class="text-lg font-bold leading-none tracking-tight">
+				{t("home.feature_card_2.title")}
+			</h2>
+
+			<div class="h-3"></div>
+
+			<p>
+				{t("home.feature_card_2.description")}
+			</p>
+		</Card>
+
+		<Card
+			size="lg"
+			href={localizePath("/resources")}
+			linkText={t("home.feature_card_3.link")}
+		>
+			<div
+				class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-rose to-love text-surface"
+			>
+				<IconHeartHandshake size={28} stroke={1.5} />
+			</div>
+
+			<div class="h-6"></div>
+
+			<h2 class="text-lg font-bold leading-none tracking-tight">
+				{t("home.feature_card_3.title")}
+			</h2>
+
+			<div class="h-3"></div>
+
+			<p>
+				{
+					t("home.feature_card_3.description", {
+						numberOfPorts: Math.floor(themes.length / 10) * 10,
+					})
+				}
+			</p>
+		</Card>
+	</section>
+</Layout>

--- a/src/pages/tr/palette/index.astro
+++ b/src/pages/tr/palette/index.astro
@@ -1,0 +1,18 @@
+---
+import { t, changeLanguage } from "i18next";
+import { roleIds } from "@rose-pine/palette";
+import PaletteLayout from "$layouts/palette.astro";
+import PaletteSwatches from "$components/palette-swatches.svelte";
+import CycleHashes from "$components/cycle-hashes.svelte";
+
+changeLanguage("tr");
+---
+
+<PaletteLayout
+	metaTitle={t("palette.title")}
+	metaDescription={t("palette.description")}
+>
+	<PaletteSwatches client:load />
+</PaletteLayout>
+
+<CycleHashes client:load hashes={roleIds} />

--- a/src/pages/tr/palette/ingredients.astro
+++ b/src/pages/tr/palette/ingredients.astro
@@ -1,0 +1,21 @@
+---
+import { t, changeLanguage } from "i18next";
+import { variantIds } from "@rose-pine/palette";
+import PaletteLayout from "$layouts/palette.astro";
+import PaletteIngredients from "$components/palette-ingredients.svelte";
+import CycleHashes from "$components/cycle-hashes.svelte";
+
+changeLanguage("tr");
+---
+
+<PaletteLayout
+	metaTitle={t("ingredients.title")}
+	metaDescription={t("ingredients.description")}
+>
+	<PaletteIngredients
+		client:load
+		decorationsLabel={t("ingredients.decorations_label") ?? "Decorations"}
+	/>
+</PaletteLayout>
+
+<CycleHashes client:load hashes={variantIds} />

--- a/src/pages/tr/resources/[...slug].astro
+++ b/src/pages/tr/resources/[...slug].astro
@@ -1,0 +1,104 @@
+---
+import i18next, { changeLanguage } from "i18next";
+import { localizePath } from "astro-i18next";
+import { getCollection, type CollectionEntry } from "astro:content";
+import Layout from "$layouts/base.astro";
+import PageIntro from "$components/page-intro.svelte";
+import Link from "$components/link.svelte";
+import { tools } from "$data/tools";
+import { getLocaleAndPath } from "src/utilities";
+
+changeLanguage("tr");
+
+const currentLanguage = i18next.language ?? "en";
+export async function getStaticPaths() {
+	const guides = await getCollection("guides");
+	return guides.map((entry) => {
+		const { path } = getLocaleAndPath(entry.id);
+		return {
+			params: { slug: path },
+			props: { entry, guides },
+		};
+	});
+}
+export type Props = {
+	entry: CollectionEntry<"guides">;
+	guides: CollectionEntry<"guides">[];
+};
+const { entry, guides } = Astro.props;
+const { path: entryPath } = getLocaleAndPath(entry.id);
+const pathsWithTranslations = new Set<string>();
+guides.forEach(({ id }) => {
+	const { locale, path } = getLocaleAndPath(id);
+	if (locale === currentLanguage) {
+		pathsWithTranslations.add(path);
+	}
+});
+const entryLanguage = pathsWithTranslations.has(entryPath)
+	? currentLanguage
+	: "en";
+const entryToRender =
+	guides.find(({ id }) => id === `${entryLanguage}/${entryPath}.md`) ?? entry;
+const { Content } = await entryToRender.render();
+---
+
+<Layout
+	title={entryToRender.data.title}
+	description={entryToRender.data.description}
+>
+	<div class="grid grid-cols-1 gap-20 lg:grid-cols-[auto,1fr]">
+		<div>
+			<PageIntro
+				heading={entryToRender.data.title}
+				subheading={entryToRender.data.description}
+			/>
+
+			<ul class="animate-enter mt-10 hidden lg:block" style="--stagger: 2">
+				<li
+					class="tracking-loose text-xs font-medium uppercase leading-loose text-subtle"
+				>
+					Resources
+				</li>
+				{
+					guides
+						.filter(({ id }) => {
+							const { locale, path } = getLocaleAndPath(id);
+							const hasTranslation = pathsWithTranslations.has(path);
+
+							return (
+								(!hasTranslation && locale === "en") ||
+								(hasTranslation && locale === currentLanguage)
+							);
+						})
+						.sort((a, b) => b.data.priority - a.data.priority)
+						.map(({ id, data }) => {
+							const { locale, path } = getLocaleAndPath(id);
+							const localizedPath = localizePath(
+								`/resources/${path}`,
+								locale === currentLanguage ? locale : undefined,
+							);
+							return (
+								<li class="leading-loose">
+									<Link href={localizedPath} decorations={false}>
+										{data.title}
+									</Link>
+								</li>
+							);
+						})
+				}
+				<hr class="my-3" />
+				{
+					tools.map(({ name, href }) => (
+						<li class="leading-loose">
+							<Link href={href}>{name}</Link>
+						</li>
+					))
+				}
+			</ul>
+		</div>
+
+		<article class="animate-enter" style="--stagger: 2">
+			<Content />
+		</article>
+	</div>
+</Layout>

--- a/src/pages/tr/resources/index.astro
+++ b/src/pages/tr/resources/index.astro
@@ -1,0 +1,107 @@
+---
+import i18next, { t, changeLanguage } from "i18next";
+import { localizePath } from "astro-i18next";
+import { getCollection } from "astro:content";
+import Layout from "$layouts/base.astro";
+import PageIntro from "$components/page-intro.svelte";
+import Card from "$components/card.svelte";
+import { tools } from "$data/tools";
+import { getLocaleAndPath } from "src/utilities";
+
+changeLanguage("tr");
+
+const currentLanguage = i18next.language ?? "en";
+const pathsWithTranslations = new Set<string>();
+const guides = await getCollection("guides", ({ id }) => {
+	const { locale, path } = getLocaleAndPath(id);
+	if (locale === currentLanguage) {
+		pathsWithTranslations.add(path);
+		return id.startsWith(`${currentLanguage}/`);
+	} else {
+		return id.startsWith("en/");
+	}
+});
+---
+
+<Layout title={t("resources.title")} description={t("resources.description")}>
+	<PageIntro
+		heading={t("resources.title")}
+		subheading={t("resources.description")}
+	>
+		<a
+			href="https://discord.gg/r6wf35KVJW"
+			class="animate-enter inline-flex h-12 items-center rounded-full bg-muted/10 px-6 font-medium transition hover:bg-muted/20 focus:outline-none focus:ring"
+			style="--stagger: 2">{t("resources.help_link")}&nbsp;&nearr;</a
+		>
+	</PageIntro>
+
+	<div class="h-20"></div>
+
+	<section class="animate-enter" style="--stagger: 2">
+		<h2 class="text-lg font-semibold tracking-tight">Guides</h2>
+
+		<div class="h-6"></div>
+
+		<ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
+			{
+				guides
+					.filter(({ id }) => {
+						const { locale, path } = getLocaleAndPath(id);
+						const hasTranslation = pathsWithTranslations.has(path);
+
+						return (
+							(!hasTranslation && locale === "en") ||
+							(hasTranslation && locale === currentLanguage)
+						);
+					})
+					.sort((a, b) => b.data.priority - a.data.priority)
+					.map(({ id, data }) => {
+						const { locale, path } = getLocaleAndPath(id);
+						const localizedPath = localizePath(
+							`/resources/${path}`,
+							locale === currentLanguage ? locale : undefined,
+						);
+						return (
+							<li>
+								<Card href={localizedPath} linkText={t("shared.read_more")}>
+									<div class="flex items-center justify-between gap-1.5">
+										<p class="w-full truncate font-semibold">{data.title}</p>
+
+										<span class="shrink-0 font-mono text-xs font-semibold uppercase text-subtle">
+											{locale}
+										</span>
+									</div>
+
+									<div class="h-1.5" />
+
+									<p>{data.description}</p>
+								</Card>
+							</li>
+						);
+					})
+			}
+		</ul>
+
+		<div class="h-20"></div>
+
+		<h2 class="text-lg font-bold tracking-tight">Tools</h2>
+
+		<div class="h-6"></div>
+
+		<ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
+			{
+				tools.map(({ name, description, href }) => (
+					<li>
+						<Card href={href} linkText="Repository">
+							<p class="font-bold">{name}</p>
+
+							<div class="h-1.5" />
+
+							<p>{description}</p>
+						</Card>
+					</li>
+				))
+			}
+		</ul>
+	</section>
+</Layout>

--- a/src/pages/tr/themes.astro
+++ b/src/pages/tr/themes.astro
@@ -1,0 +1,34 @@
+---
+import { t, changeLanguage } from "i18next";
+import Layout from "$layouts/base.astro";
+import PageIntro from "$components/page-intro.svelte";
+import ThemesFilter from "$components/themes-filter.svelte";
+import ThemesTagsList from "$components/themes-tags-list.svelte";
+import ThemesList from "$components/themes-list.svelte";
+import { themes, authors } from "$data/themes";
+
+changeLanguage("tr");
+---
+
+<Layout title={t("themes.title")} description={t("themes.description")}>
+	<PageIntro
+		heading={t("themes.title")}
+		subheading={t("themes.description")}
+		tagline={t("themes.tagline", {
+			numberOfPorts: themes.length,
+			numberOfAuthors: authors.size,
+		})}
+	>
+		<ThemesFilter client:load label={t("themes.search_label")} />
+	</PageIntro>
+
+	<div class="h-20"></div>
+
+	<section class="animate-enter" style="--stagger: 2">
+		<ThemesTagsList client:load />
+
+		<div class="h-10"></div>
+
+		<ThemesList client:load />
+	</section>
+</Layout>

--- a/src/pages/tr/themes/cursor.astro
+++ b/src/pages/tr/themes/cursor.astro
@@ -1,0 +1,41 @@
+---
+import { changeLanguage } from "i18next";
+import Layout from "$layouts/base.astro";
+import PageIntro from "$components/page-intro.svelte";
+
+changeLanguage("tr");
+---
+
+<Layout title="Rosé Pine Cursor" description="Soho vibes for your mouse cursor">
+	<PageIntro
+		heading="Rosé Pine Cursors"
+		subheading="Point, click, and drag with a lil extra flair."
+	>
+		<a
+			href="https://github.com/rose-pine/cursor"
+			class="animate-enter inline-flex h-12 items-center rounded-full bg-muted/10 px-6 font-medium transition hover:bg-muted/20 focus:outline-none focus:ring"
+			style="--stagger: 2">Download &nbsp;&nearr;</a
+		>
+	</PageIntro>
+
+	<div class="h-20"></div>
+
+	<section class="animate-enter" style="--stagger: 2">
+		<p class="max-w-prose text-4xl font-bold tracking-tight">
+			You'll want to learn how to quit vim for this one, folks. Special thanks
+			to <a
+				href="https://github.com/ThatOneCalculator"
+				class="text-love underline decoration-love decoration-wavy underline-offset-8 hover:no-underline"
+				>ThatOneCalculator</a
+			>
+			 🎉
+		</p>
+		<div class="h-20"></div>
+		<div
+			class="grid grid-cols-1 gap-3 sm:grid-cols-2 [&>img]:rounded-lg [&>img]:border"
+		>
+			<img src="/cursor-dark.png" alt="Rosé Pine for Cursors" />
+			<img src="/cursor-light.png" alt="Rosé Pine Dawn for Cursors" />
+		</div>
+	</section>
+</Layout>

--- a/src/pages/tr/themes/index.astro
+++ b/src/pages/tr/themes/index.astro
@@ -1,0 +1,34 @@
+---
+import { t, changeLanguage } from "i18next";
+import Layout from "$layouts/base.astro";
+import PageIntro from "$components/page-intro.svelte";
+import ThemesFilter from "$components/themes-filter.svelte";
+import ThemesTagsList from "$components/themes-tags-list.svelte";
+import ThemesList from "$components/themes-list.svelte";
+import { themes, authors } from "$data/themes";
+
+changeLanguage("tr");
+---
+
+<Layout title={t("themes.title")} description={t("themes.description")}>
+	<PageIntro
+		heading={t("themes.title")}
+		subheading={t("themes.description")}
+		tagline={t("themes.tagline", {
+			numberOfPorts: themes.length,
+			numberOfAuthors: authors.size,
+		})}
+	>
+		<ThemesFilter client:load label={t("themes.search_label")} />
+	</PageIntro>
+
+	<div class="h-20"></div>
+
+	<section class="animate-enter" style="--stagger: 2">
+		<ThemesTagsList client:load />
+
+		<div class="h-10"></div>
+
+		<ThemesList client:load />
+	</section>
+</Layout>


### PR DESCRIPTION
Hello! this pull request adds Turkish translation to Rosé Pine's website and guides.

Some concerns I have:
- The "Home" translation in src/locales/tr.json is Sentence case. If it's needed to be Title Case, feel free to change it or tell to me.
- Even though I uploaded the files I tested on a local environment to GitHub, I'm not entirely sure if it will work. Although it should.
- I couldn't find an equivalent for the string "create an issue" in create-a-theme.md in Turkish. So, I changed the translation to "Open a sorun (issue) in GitHub" for better understanding.