### PR TITLE
Feat: rose-pine-man theme

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -234,7 +234,7 @@
 	{
 		"name": "man",
 		"url": "https://github.com/const-void/rose-pine-man",
-		"tags": ["terminal", "shell"],
+		"tags": ["community", "shell"],
 		"authors": [
 			{ "name": "const void*", "url": "https://github.com/const-void" }
 		],

--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -232,6 +232,15 @@
 		"has_variants": true
 	},
 	{
+		"name": "man",
+		"url": "https://github.com/const-void/rose-pine-man",
+		"tags": ["terminal", "shell"],
+		"authors": [
+			{ "name": "const void*", "url": "https://github.com/const-void" }
+		],
+		"has_variants": true
+	},
+	{
 		"name": "Marp",
 		"url": "https://github.com/rainbowflesh/Rose-Pine-For-Marp",
 		"tags": ["marp-themes"],


### PR DESCRIPTION
b&w man pages are totes boring; `oh-my-zsh` man colors are nice, but they are locked in to...base16? thought  a scratch-built `rose-pine man` truecolor (16m) color theme would be cool, esp with the ability to rotate themes in real-time, as well as customize.  Hope the PR was done correctly!  

ty for the time and attention to the community rose-pine maintainers. you are very much appreciated! 