### PR TITLE
add rEFInd

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -320,6 +320,15 @@
 		"has_variants": false
 	},
 	{
+		"name": "rEFInd",
+		"url": "https://github.com/xlacroixx/refind",
+		"tags": [],
+		"authors": [
+			{ "name": "LACROIXX", "url": "https://codeberg.org/xlacroixx" }
+		],
+		"has_variants": true
+	},
+	{
 		"name": "RIME",
 		"url": "https://github.com/0xffan/rose-pine-rime",
 		"tags": [],


### PR DESCRIPTION
rEFInd is a boot manager, forked from rEFIt, that supports theming and icons (afaik the only one along with BURG).

My theme supports all variants. You can find it at https://github.com/xlacroixx/rose-pine-refind.

However, icons have a pretty bad aliasing effect; I may improve it in the future: I'll maybe rewrite the generation script to use a more robust image processing program, but I do not doubt that official/specific OS icons would be the best choice.

Hope to hear from you!