### PR TITLE
Update foot theme ownership

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -96,10 +96,11 @@
 	},
 	{
 		"name": "foot",
-		"url": "https://github.com/EuCaue/foot",
-		"tags": ["terminal-emulator"],
+		"url": "https://github.com/d2718nis/rose-pine-foot",
+		"tags": ["app", "terminal", "terminal-emulator"],
 		"authors": [
 			{ "name": "EuCaue", "url": "https://github.com/EuCaue" },
+			{ "name": "d2718nis", "url": "https://github.com/d2718nis" },
 			{ "name": "cement-drinker", "url": "https://github.com/cement-drinker" }
 		],
 		"has_variants": true


### PR DESCRIPTION
Hi there!

As discussed with the previous maintainer [here](https://github.com/EuCaue/foot/issues/7), I will be taking over as the new maintainer of the [Rosé Pine theme](https://github.com/d2718nis/rose-pine-foot) for the [foot](https://codeberg.org/dnkl/foot) terminal emulator. I plan to polish the showcase and potentially make other improvements soon.

Thank you!