### PR TITLE
Update community-repos.json to add the Rosé Pine icon theme

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -500,5 +500,15 @@
 		"tags": ["app"],
 		"authors": [{ "name": "bilaii", "url": "https://github.com/BilayJr" }],
 		"has_variants": true
+	},
+
+		{
+                "name": "Icon Theme",
+  		"url": "https://github.com/Henriquehnnm/rose-pine-icon-theme",
+		"tags": ["palette"],
+		"authors": [{"name": "HenriqueHnnm", "url": "https://github.com/Henriquehnnm"}],
+		"has_variants": true
 	}
+
+
 ]


### PR DESCRIPTION
This update adds the Rosé Pine icon theme to the community-repos.json file, expanding the collection of icon themes available for users. The Rosé Pine icon theme is known for its elegant, soft color palette and aesthetic appeal, designed to provide a smooth, visually-pleasing experience. By adding it to the community repository, we aim to make it easier for users to access and enjoy a beautiful, consistent look for their desktop environments. This addition will further enhance the diversity and variety of icon themes offered in the repository.
## Rosé Pine
![rosepine](https://github.com/user-attachments/assets/75cb60fc-0e5d-42ca-9443-0586f88fd689)

## Rosé Pine Moon
![moon](https://github.com/user-attachments/assets/37172a18-b4da-4221-9c4d-2d02b042d94f)

## Rosé Pine Dawn
![dawn](https://github.com/user-attachments/assets/1cb2ae71-f5c6-4560-b315-7e76d29ba97e)
