### PR TITLE
Add link to markdown viewer community repo

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -238,6 +238,15 @@
 		"has_variants": true
 	},
 	{
+		"name": "Markdown Viewer",
+		"url": "https://github.com/Swefton/markdown-viewer",
+		"tags": ["extension", "css"],
+		"authors" : [
+			{ "name": "Swefton", "url": "https://github.com/Swefton"}
+		],
+		"has_variants": true
+	},
+	{
 		"name": "Marp",
 		"url": "https://github.com/rainbowflesh/Rose-Pine-For-Marp",
 		"tags": ["marp-themes"],


### PR DESCRIPTION
Hi, I wanted to add this theme I created for [Markdown Viewer](https://chromewebstore.google.com/detail/markdown-viewer/ckkdlimhmcjmikdlpkmbgfkaikojcbjk).

It supports all three variants and the repoistory and standards should be consistent with the requirements.