### PR TITLE
Add Chatterino community theme

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -30,6 +30,13 @@
 		"has_variants": true
 	},
 	{
+		"name": "Chatterino",
+		"url": "https://github.com/nofishleft/rose-pine-chatterino",
+		"tags": ["app", "community"],
+		"authors": [{ "name": "nofishleft (phush)", "url": "https://github.com/nofishleft" }],
+		"has_variants": true
+	},
+	{
 		"name": "Chrome Devtools",
 		"url": "https://github.com/velzie/rose-pine-chrome-devtools",
 		"tags": ["browser", "chrome", "chromium"],


### PR DESCRIPTION
Theme for Chatterino, a twitch chat client with builtin support for 7tv, bttv and ffz.

https://github.com/nofishleft/rose-pine-chatterino

https://chatterino.com
https://github.com/chatterino/chatterino2
https://github.com/SevenTV/chatterino7