### PR TITLE
Update community-repos.json

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -543,6 +543,14 @@
 		"tags": ["palette"],
 		"authors": [{"name": "HenriqueHnnm", "url": "https://github.com/Henriquehnnm"}],
 		"has_variants": true
+	},
+
+			{
+                "name": "Gnome Builder",
+  		"url": "https://github.com/Henriquehnnm/gnome-builder",
+		"tags": ["editor"],
+		"authors": [{"name": "HenriqueHnnm", "url": "https://github.com/Henriquehnnm"}],
+		"has_variants": true
 	}
 
 


### PR DESCRIPTION
Hello!
I added pro rose pine themes to gnome builder (it also works in gnome text editor)
<img width="1473" height="751" alt="rose-pine" src="https://github.com/user-attachments/assets/d07a583e-f6a4-41b7-affd-5970a3c03e4d" />
<img width="1473" height="751" alt="rose-pine-moon" src="https://github.com/user-attachments/assets/ce09dc0a-9ec1-4ec9-bdd5-8bc9ee5c1a46" />
<img width="1473" height="751" alt="rose-pine-dawn" src="https://github.com/user-attachments/assets/9b7ddc66-15d5-4947-a6fd-bab31c3a0e96" />


I hope you like it!