### PR TITLE
Removing Gnome Builder from community repositories

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -543,14 +543,6 @@
 		"tags": ["palette"],
 		"authors": [{"name": "HenriqueHnnm", "url": "https://github.com/Henriquehnnm"}],
 		"has_variants": true
-	},
-
-			{
-                "name": "Gnome Builder",
-  		"url": "https://github.com/Henriquehnnm/gnome-builder",
-		"tags": ["editor"],
-		"authors": [{"name": "HenriqueHnnm", "url": "https://github.com/Henriquehnnm"}],
-		"has_variants": true
 	}
 
 


### PR DESCRIPTION
Hello again! I removed Gnome Builder from the community repositories leaving it only in the Org repositories