### PR TITLE
Add JetBrains IDE theme

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -159,6 +159,13 @@
 		"has_variants": true
 	},
 	{
+		"name": "JetBrains IDE (IntelliJ, PyCharm, GoLand, etc.)",
+		"url": "https://github.com/bomgar/rose-pine-jetbrains",
+		"tags": ["app", "editor"],
+		"authors": [{ "name": "bomgar", "url": "https://github.com/bomgar" }],
+		"has_variants": true
+	},
+	{
 		"name": "iSH Shell",
 		"url": "https://github.com/akopdev/rose-pine-ish",
 		"tags": ["terminal", "shell", "mobile", "ish"],


### PR DESCRIPTION
There is already https://github.com/jmorjsm/rose-pine-intellij

But the project has not been updated since 2023. It also looks abandoned to me.