### PR TITLE
Add Glow repository to community-repos.json

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -147,6 +147,15 @@
 		"has_variants": true
 	},
 	{
+		"name": "Glow",
+		"url": "https://github.com/drluckyspin/rose-pine-glow",
+		"tags": ["terminal", "shell", "glow", "markdown"],
+		"authors": [
+			{ "name": "drluckyspin", "url": "https://github.com/drluckyspin" }
+		],
+		"has_variants": true
+	},
+	{
 		"name": "Gradience Presets",
 		"url": "https://github.com/gradience-presets?q=rose&type=all&sort=",
 		"tags": ["adwaita", "ui"],


### PR DESCRIPTION
This pull request adds a new community repository entry to the `src/data/community-repos.json` file.

Community repository additions:

* Added a new entry for "Glow" markdown viewer themes.