### PR TITLE
feat: add Nimbalyst editor theme

### DIFF
--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -327,6 +327,15 @@
 		"has_variants": true
 	},
 	{
+		"name": "Nimbalyst",
+		"url": "https://github.com/omartelo/rose-pine-nimbalyst",
+		"tags": ["app", "editor", "Nimbalyst"],
+		"authors": [
+			{ "name": "omartelo", "url": "https://github.com/omartelo" }
+		],
+		"has_variants": true
+	},
+	{
 		"name": "Notepad++",
 		"url": "https://github.com/aaravind100/notepad-plus-plus",
 		"tags": ["app", "editor"],

--- a/src/data/community-repos.json
+++ b/src/data/community-repos.json
@@ -329,7 +329,7 @@
 	{
 		"name": "Nimbalyst",
 		"url": "https://github.com/omartelo/rose-pine-nimbalyst",
-		"tags": ["app", "editor", "Nimbalyst"],
+		"tags": ["app", "editor", "nimbalyst"],
 		"authors": [
 			{ "name": "omartelo", "url": "https://github.com/omartelo" }
 		],


### PR DESCRIPTION
## Summary

Adds the [Rosé Pine theme for Nimbalyst](https://github.com/omartelo/rose-pine-nimbalyst) to the community repos list.

Nimbalyst is an AI-native workspace and code editor. The extension ships all three Rosé Pine variants (Rosé Pine, Moon, Dawn).

## Entry

Inserted alphabetically between `MPV.net` and `Notepad++`:

```json
{
    "name": "Nimbalyst",
    "url": "https://github.com/omartelo/rose-pine-nimbalyst",
    "tags": ["app", "editor", "Nimbalyst"],
    "authors": [
        { "name": "omartelo", "url": "https://github.com/omartelo" }
    ],
    "has_variants": true
}
```

## Checklist

- [x] Colours follow the [Rosé Pine palette](https://rosepinetheme.com/palette)
- [x] All three variants supported (`has_variants: true`)
- [x] Repo is public
- [x] Alphabetical position preserved
- [x] JSON validates