### PR TITLE
fix malformed repo URLs

### DIFF
--- a/scripts/update-data.ts
+++ b/scripts/update-data.ts
@@ -36,7 +36,7 @@ const workers = Array.from({ length: 10 }, async () => {
 	while (index < visible.length) {
 		const i = index++;
 		const repo = visible[i];
-		const { name, stargazers_count, updated_at, topics } = repo;
+		const { name, html_url, stargazers_count, updated_at, topics } = repo;
 		const customProperties = (repo as any).custom_properties as
 			Record<string, string> | undefined;
 
@@ -110,6 +110,7 @@ const workers = Array.from({ length: 10 }, async () => {
 
 		const data: Record<string, unknown> = {
 			...(displayName && { name: displayName }),
+			url: html_url,
 			category: customProperties?.category ?? "",
 			stargazersCount: stargazers_count,
 			updatedAt: updated_at,

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -22,6 +22,7 @@ export const collections = {
 		}),
 		schema: z.object({
 			featured: z.boolean().optional(),
+			url: z.string(),
 			stargazersCount: z.number(),
 			updatedAt: z.date().optional(),
 			tags: z.array(z.string()).optional(),

--- a/src/content/official-repos/ableton-live.yaml
+++ b/src/content/official-repos/ableton-live.yaml
@@ -1,7 +1,8 @@
 name: Ableton Live
+url: https://github.com/rose-pine/ableton-live
 category: editor
-stargazersCount: 2
-updatedAt: 2026-06-25T08:44:36Z
+stargazersCount: 3
+updatedAt: 2026-06-29T22:05:43Z
 contributors:
   - name: juliamertz
     url: https://github.com/juliamertz

--- a/src/content/official-repos/alacritty.yaml
+++ b/src/content/official-repos/alacritty.yaml
@@ -1,4 +1,5 @@
 name: Alacritty
+url: https://github.com/rose-pine/alacritty
 category: terminal
 stargazersCount: 144
 updatedAt: 2026-06-13T11:00:24Z

--- a/src/content/official-repos/alfred.yaml
+++ b/src/content/official-repos/alfred.yaml
@@ -1,4 +1,5 @@
 name: Alfred
+url: https://github.com/rose-pine/alfred
 category: system
 stargazersCount: 4
 updatedAt: 2026-06-25T08:07:35Z

--- a/src/content/official-repos/aliucord.yaml
+++ b/src/content/official-repos/aliucord.yaml
@@ -1,4 +1,5 @@
 name: Aliucord
+url: https://github.com/rose-pine/aliucord
 category: social
 stargazersCount: 4
 updatedAt: 2025-11-05T14:45:55Z

--- a/src/content/official-repos/amfora.yaml
+++ b/src/content/official-repos/amfora.yaml
@@ -1,4 +1,5 @@
 name: Amfora
+url: https://github.com/rose-pine/amfora
 category: terminal
 stargazersCount: 9
 updatedAt: 2025-11-05T14:45:57Z

--- a/src/content/official-repos/anytype.yaml
+++ b/src/content/official-repos/anytype.yaml
@@ -1,4 +1,5 @@
 name: Anytype
+url: https://github.com/rose-pine/anytype
 category: editor
 stargazersCount: 15
 updatedAt: 2026-05-25T18:02:18Z

--- a/src/content/official-repos/atom.yaml
+++ b/src/content/official-repos/atom.yaml
@@ -1,4 +1,5 @@
 name: Atom
+url: https://github.com/rose-pine/atom
 category: editor
 stargazersCount: 6
 updatedAt: 2025-11-05T14:46:00Z

--- a/src/content/official-repos/bear-blog.yaml
+++ b/src/content/official-repos/bear-blog.yaml
@@ -1,4 +1,5 @@
 name: Bear Blog
+url: https://github.com/rose-pine/bear-blog
 category: browser
 stargazersCount: 11
 updatedAt: 2026-02-20T11:25:05Z

--- a/src/content/official-repos/black-box.yaml
+++ b/src/content/official-repos/black-box.yaml
@@ -1,4 +1,5 @@
 name: Black Box
+url: https://github.com/rose-pine/black-box
 category: terminal
 stargazersCount: 9
 updatedAt: 2025-11-05T14:46:01Z

--- a/src/content/official-repos/bspwm.yaml
+++ b/src/content/official-repos/bspwm.yaml
@@ -1,4 +1,5 @@
 name: bspwm
+url: https://github.com/rose-pine/bspwm
 category: system
 stargazersCount: 12
 updatedAt: 2026-03-23T21:11:17Z

--- a/src/content/official-repos/btop.yaml
+++ b/src/content/official-repos/btop.yaml
@@ -1,4 +1,5 @@
 name: btop
+url: https://github.com/rose-pine/btop
 category: terminal
 stargazersCount: 43
 updatedAt: 2026-03-14T02:40:47Z

--- a/src/content/official-repos/cava.yaml
+++ b/src/content/official-repos/cava.yaml
@@ -1,4 +1,5 @@
 name: Cava
+url: https://github.com/rose-pine/cava
 category: editor
 stargazersCount: 18
 updatedAt: 2026-06-24T19:59:14Z

--- a/src/content/official-repos/code-quick-tester.yaml
+++ b/src/content/official-repos/code-quick-tester.yaml
@@ -1,4 +1,5 @@
 name: CodeQuickTester
+url: https://github.com/rose-pine/code-quick-tester
 category: editor
 stargazersCount: 0
 updatedAt: 2025-11-05T14:46:06Z

--- a/src/content/official-repos/cool-retro-term.yaml
+++ b/src/content/official-repos/cool-retro-term.yaml
@@ -1,4 +1,5 @@
 name: cool-retro-term
+url: https://github.com/rose-pine/cool-retro-term
 category: terminal
 stargazersCount: 6
 updatedAt: 2025-11-05T14:46:08Z

--- a/src/content/official-repos/cosmic-desktop.yaml
+++ b/src/content/official-repos/cosmic-desktop.yaml
@@ -1,4 +1,5 @@
 name: COSMIC Desktop
+url: https://github.com/rose-pine/cosmic-desktop
 category: system
 stargazersCount: 15
 updatedAt: 2026-06-26T04:49:58Z

--- a/src/content/official-repos/ct.js.yaml
+++ b/src/content/official-repos/ct.js.yaml
@@ -1,4 +1,5 @@
 name: ct.js
+url: https://github.com/rose-pine/ct.js
 category: editor
 stargazersCount: 3
 updatedAt: 2025-11-05T14:46:09Z

--- a/src/content/official-repos/cursors.yaml
+++ b/src/content/official-repos/cursors.yaml
@@ -1,4 +1,5 @@
 name: Cursors
+url: https://github.com/rose-pine/cursors
 category: system
 stargazersCount: 180
 updatedAt: 2026-06-28T09:40:11Z

--- a/src/content/official-repos/daisyui.yaml
+++ b/src/content/official-repos/daisyui.yaml
@@ -1,4 +1,5 @@
 name: daisyUI
+url: https://github.com/rose-pine/daisyui
 category: library
 stargazersCount: 22
 updatedAt: 2026-04-05T18:33:14Z

--- a/src/content/official-repos/dark-reader.yaml
+++ b/src/content/official-repos/dark-reader.yaml
@@ -1,4 +1,5 @@
 name: Dark Reader
+url: https://github.com/rose-pine/dark-reader
 category: browser
 stargazersCount: 49
 updatedAt: 2026-05-26T16:13:07Z

--- a/src/content/official-repos/desmos-desktop.yaml
+++ b/src/content/official-repos/desmos-desktop.yaml
@@ -1,4 +1,5 @@
 name: Desmos Desktop
+url: https://github.com/rose-pine/desmos-desktop
 category: editor
 stargazersCount: 4
 updatedAt: 2026-02-28T23:15:54Z

--- a/src/content/official-repos/discord-mobile.yaml
+++ b/src/content/official-repos/discord-mobile.yaml
@@ -1,4 +1,5 @@
 name: Discord Mobile
+url: https://github.com/rose-pine/discord-mobile
 category: social
 stargazersCount: 21
 updatedAt: 2026-06-27T09:07:17Z

--- a/src/content/official-repos/discord-rpc-maker.yaml
+++ b/src/content/official-repos/discord-rpc-maker.yaml
@@ -1,4 +1,5 @@
 name: Discord RPC Maker
+url: https://github.com/rose-pine/discord-rpc-maker
 category: editor
 stargazersCount: 1
 updatedAt: 2025-11-05T14:46:17Z

--- a/src/content/official-repos/discord.yaml
+++ b/src/content/official-repos/discord.yaml
@@ -1,7 +1,8 @@
 name: Discord
+url: https://github.com/rose-pine/discord
 category: social
-stargazersCount: 121
-updatedAt: 2026-06-26T22:25:03Z
+stargazersCount: 122
+updatedAt: 2026-06-29T09:59:11Z
 tags:
   - betterdiscord
   - goosemod

--- a/src/content/official-repos/dwm.yaml
+++ b/src/content/official-repos/dwm.yaml
@@ -1,4 +1,5 @@
 name: dwm
+url: https://github.com/rose-pine/dwm
 category: system
 stargazersCount: 2
 updatedAt: 2025-11-05T14:46:17Z

--- a/src/content/official-repos/fcitx5.yaml
+++ b/src/content/official-repos/fcitx5.yaml
@@ -1,4 +1,5 @@
 name: fcitx5
+url: https://github.com/rose-pine/fcitx5
 category: system
 stargazersCount: 7
 updatedAt: 2026-04-15T08:36:25Z

--- a/src/content/official-repos/figma.yaml
+++ b/src/content/official-repos/figma.yaml
@@ -1,4 +1,5 @@
 name: Figma
+url: https://github.com/rose-pine/figma
 category: editor
 stargazersCount: 2
 updatedAt: 2026-06-07T17:23:41Z

--- a/src/content/official-repos/firefox.yaml
+++ b/src/content/official-repos/firefox.yaml
@@ -1,4 +1,5 @@
 name: Firefox
+url: https://github.com/rose-pine/firefox
 category: browser
 stargazersCount: 100
 updatedAt: 2026-06-22T09:55:51Z

--- a/src/content/official-repos/fish.yaml
+++ b/src/content/official-repos/fish.yaml
@@ -1,4 +1,5 @@
 name: fish
+url: https://github.com/rose-pine/fish
 category: terminal
 stargazersCount: 45
 updatedAt: 2026-06-03T23:37:07Z

--- a/src/content/official-repos/flow-launcher.yaml
+++ b/src/content/official-repos/flow-launcher.yaml
@@ -1,4 +1,5 @@
 name: Flow Launcher
+url: https://github.com/rose-pine/flow-launcher
 category: system
 stargazersCount: 3
 updatedAt: 2026-03-27T11:22:13Z

--- a/src/content/official-repos/fluent-terminal.yaml
+++ b/src/content/official-repos/fluent-terminal.yaml
@@ -1,4 +1,5 @@
 name: Fluent Terminal
+url: https://github.com/rose-pine/fluent-terminal
 category: terminal
 stargazersCount: 7
 updatedAt: 2025-11-05T14:46:23Z

--- a/src/content/official-repos/foot.yaml
+++ b/src/content/official-repos/foot.yaml
@@ -1,4 +1,5 @@
 name: foot
+url: https://github.com/rose-pine/foot
 category: terminal
 stargazersCount: 17
 updatedAt: 2026-03-28T10:18:31Z

--- a/src/content/official-repos/fzf.yaml
+++ b/src/content/official-repos/fzf.yaml
@@ -1,4 +1,5 @@
 name: fzf
+url: https://github.com/rose-pine/fzf
 category: terminal
 stargazersCount: 34
 updatedAt: 2026-03-28T21:19:14Z

--- a/src/content/official-repos/gdevelop.yaml
+++ b/src/content/official-repos/gdevelop.yaml
@@ -1,4 +1,5 @@
 name: GDevelop
+url: https://github.com/rose-pine/gdevelop
 category: editor
 stargazersCount: 2
 updatedAt: 2025-11-05T14:46:26Z

--- a/src/content/official-repos/geany.yaml
+++ b/src/content/official-repos/geany.yaml
@@ -1,4 +1,5 @@
 name: Geany
+url: https://github.com/rose-pine/geany
 category: editor
 stargazersCount: 0
 updatedAt: 2025-11-05T14:46:27Z

--- a/src/content/official-repos/ghostty.yaml
+++ b/src/content/official-repos/ghostty.yaml
@@ -1,4 +1,5 @@
 name: Ghostty
+url: https://github.com/rose-pine/ghostty
 category: terminal
 stargazersCount: 64
 updatedAt: 2026-06-25T19:20:05Z

--- a/src/content/official-repos/github-readme-stats.yaml
+++ b/src/content/official-repos/github-readme-stats.yaml
@@ -1,4 +1,5 @@
 name: GitHub Readme Stats
+url: https://github.com/rose-pine/github-readme-stats
 category: browser
 stargazersCount: 12
 updatedAt: 2026-06-28T07:43:23Z

--- a/src/content/official-repos/gitkraken.yaml
+++ b/src/content/official-repos/gitkraken.yaml
@@ -1,4 +1,5 @@
 name: GitKraken
+url: https://github.com/rose-pine/gitkraken
 category: editor
 stargazersCount: 7
 updatedAt: 2026-04-11T01:26:46Z

--- a/src/content/official-repos/glazewm.yaml
+++ b/src/content/official-repos/glazewm.yaml
@@ -1,4 +1,5 @@
 name: GlazeWM
+url: https://github.com/rose-pine/glazewm
 category: system
 stargazersCount: 7
 updatedAt: 2025-11-05T14:46:31Z

--- a/src/content/official-repos/gnome-builder.yaml
+++ b/src/content/official-repos/gnome-builder.yaml
@@ -1,4 +1,5 @@
 name: GNOME Builder
+url: https://github.com/rose-pine/gnome-builder
 category: editor
 stargazersCount: 0
 updatedAt: 2026-03-16T18:27:20Z

--- a/src/content/official-repos/gnome-terminal.yaml
+++ b/src/content/official-repos/gnome-terminal.yaml
@@ -1,4 +1,5 @@
 name: GNOME Terminal
+url: https://github.com/rose-pine/gnome-terminal
 category: terminal
 stargazersCount: 55
 updatedAt: 2026-04-06T14:03:12Z

--- a/src/content/official-repos/google-chrome.yaml
+++ b/src/content/official-repos/google-chrome.yaml
@@ -1,4 +1,5 @@
 name: Chrome
+url: https://github.com/rose-pine/google-chrome
 category: browser
 stargazersCount: 69
 updatedAt: 2026-06-28T06:23:58Z

--- a/src/content/official-repos/gotosocial.yaml
+++ b/src/content/official-repos/gotosocial.yaml
@@ -1,4 +1,5 @@
 name: GoToSocial
+url: https://github.com/rose-pine/gotosocial
 category: browser
 stargazersCount: 0
 updatedAt: 2025-12-14T16:57:29Z

--- a/src/content/official-repos/grub.yaml
+++ b/src/content/official-repos/grub.yaml
@@ -1,4 +1,5 @@
 name: GRUB
+url: https://github.com/rose-pine/grub
 category: system
 stargazersCount: 21
 updatedAt: 2026-04-27T04:56:17Z

--- a/src/content/official-repos/gtk.yaml
+++ b/src/content/official-repos/gtk.yaml
@@ -1,4 +1,5 @@
 name: GTK
+url: https://github.com/rose-pine/gtk
 category: system
 stargazersCount: 337
 updatedAt: 2026-06-25T09:00:04Z

--- a/src/content/official-repos/helix.yaml
+++ b/src/content/official-repos/helix.yaml
@@ -1,4 +1,5 @@
 name: Helix
+url: https://github.com/rose-pine/helix
 category: editor
 stargazersCount: 39
 updatedAt: 2026-04-16T23:44:06Z

--- a/src/content/official-repos/hljs.yaml
+++ b/src/content/official-repos/hljs.yaml
@@ -1,4 +1,5 @@
 name: highlight.js
+url: https://github.com/rose-pine/hljs
 category: library
 stargazersCount: 6
 updatedAt: 2026-06-18T20:05:53Z

--- a/src/content/official-repos/home-assistant.yaml
+++ b/src/content/official-repos/home-assistant.yaml
@@ -1,4 +1,5 @@
 name: Home Assistant
+url: https://github.com/rose-pine/home-assistant
 category: none
 stargazersCount: 15
 updatedAt: 2026-06-24T17:04:26Z

--- a/src/content/official-repos/hyper.yaml
+++ b/src/content/official-repos/hyper.yaml
@@ -1,4 +1,5 @@
 name: Hyper
+url: https://github.com/rose-pine/hyper
 category: terminal
 stargazersCount: 38
 updatedAt: 2026-06-20T04:08:26Z

--- a/src/content/official-repos/hyprland.yaml
+++ b/src/content/official-repos/hyprland.yaml
@@ -1,4 +1,5 @@
 name: Hyprland
+url: https://github.com/rose-pine/hyprland
 category: system
 stargazersCount: 35
 updatedAt: 2026-06-27T01:15:53Z

--- a/src/content/official-repos/i3.yaml
+++ b/src/content/official-repos/i3.yaml
@@ -1,4 +1,5 @@
 name: i3
+url: https://github.com/rose-pine/i3
 category: system
 stargazersCount: 15
 updatedAt: 2026-06-24T20:00:47Z

--- a/src/content/official-repos/instatus.yaml
+++ b/src/content/official-repos/instatus.yaml
@@ -1,4 +1,5 @@
 name: Instatus
+url: https://github.com/rose-pine/instatus
 category: browser
 stargazersCount: 1
 updatedAt: 2025-11-05T14:46:43Z

--- a/src/content/official-repos/iterm.yaml
+++ b/src/content/official-repos/iterm.yaml
@@ -1,4 +1,5 @@
 name: iTerm2
+url: https://github.com/rose-pine/iterm
 category: terminal
 stargazersCount: 140
 updatedAt: 2026-06-08T02:00:49Z

--- a/src/content/official-repos/jdownloader.yaml
+++ b/src/content/official-repos/jdownloader.yaml
@@ -1,4 +1,5 @@
 name: JDownloader
+url: https://github.com/rose-pine/jdownloader
 category: editor
 stargazersCount: 7
 updatedAt: 2026-06-27T10:23:05Z

--- a/src/content/official-repos/kate.yaml
+++ b/src/content/official-repos/kate.yaml
@@ -1,4 +1,5 @@
 name: Kate
+url: https://github.com/rose-pine/kate
 category: editor
 stargazersCount: 2
 updatedAt: 2026-03-03T12:09:14Z

--- a/src/content/official-repos/kitty.yaml
+++ b/src/content/official-repos/kitty.yaml
@@ -1,4 +1,5 @@
 name: kitty
+url: https://github.com/rose-pine/kitty
 category: terminal
 stargazersCount: 123
 updatedAt: 2026-06-25T09:00:07Z

--- a/src/content/official-repos/konsole.yaml
+++ b/src/content/official-repos/konsole.yaml
@@ -1,4 +1,5 @@
 name: Konsole
+url: https://github.com/rose-pine/konsole
 category: terminal
 stargazersCount: 18
 updatedAt: 2026-06-06T07:33:34Z

--- a/src/content/official-repos/kvantum.yaml
+++ b/src/content/official-repos/kvantum.yaml
@@ -1,4 +1,5 @@
 name: Kvantum
+url: https://github.com/rose-pine/kvantum
 category: editor
 stargazersCount: 7
 updatedAt: 2026-05-04T13:23:20Z

--- a/src/content/official-repos/lazygit.yaml
+++ b/src/content/official-repos/lazygit.yaml
@@ -1,4 +1,5 @@
 name: lazygit
+url: https://github.com/rose-pine/lazygit
 category: terminal
 stargazersCount: 8
 updatedAt: 2026-05-21T05:00:58Z

--- a/src/content/official-repos/limine.yaml
+++ b/src/content/official-repos/limine.yaml
@@ -1,4 +1,5 @@
 name: Limine
+url: https://github.com/rose-pine/limine
 category: system
 stargazersCount: 4
 updatedAt: 2026-05-26T21:57:51Z

--- a/src/content/official-repos/linear.yaml
+++ b/src/content/official-repos/linear.yaml
@@ -1,4 +1,5 @@
 name: Linear
+url: https://github.com/rose-pine/linear
 category: browser
 stargazersCount: 0
 updatedAt: 2025-11-05T14:46:52Z

--- a/src/content/official-repos/linux-tty.yaml
+++ b/src/content/official-repos/linux-tty.yaml
@@ -1,4 +1,5 @@
 name: Linux TTY
+url: https://github.com/rose-pine/linux-tty
 category: terminal
 stargazersCount: 16
 updatedAt: 2026-01-27T09:22:15Z

--- a/src/content/official-repos/lxterminal.yaml
+++ b/src/content/official-repos/lxterminal.yaml
@@ -1,4 +1,5 @@
 name: LXTerminal
+url: https://github.com/rose-pine/lxterminal
 category: terminal
 stargazersCount: 3
 updatedAt: 2025-11-05T14:46:55Z

--- a/src/content/official-repos/mailspring.yaml
+++ b/src/content/official-repos/mailspring.yaml
@@ -1,4 +1,5 @@
 name: MailSpring
+url: https://github.com/rose-pine/mailspring
 category: social
 stargazersCount: 4
 updatedAt: 2025-11-05T15:00:10Z

--- a/src/content/official-repos/mako.yaml
+++ b/src/content/official-repos/mako.yaml
@@ -1,4 +1,5 @@
 name: mako
+url: https://github.com/rose-pine/mako
 category: system
 stargazersCount: 4
 updatedAt: 2026-05-14T18:15:41Z

--- a/src/content/official-repos/markdown-viewer.yaml
+++ b/src/content/official-repos/markdown-viewer.yaml
@@ -1,4 +1,5 @@
 name: Markdown Viewer
+url: https://github.com/rose-pine/markdown-viewer
 category: browser
 stargazersCount: 3
 updatedAt: 2026-02-28T23:27:54Z

--- a/src/content/official-repos/mastodon.yaml
+++ b/src/content/official-repos/mastodon.yaml
@@ -1,4 +1,5 @@
 name: Mastodon
+url: https://github.com/rose-pine/mastodon
 category: social
 stargazersCount: 5
 updatedAt: 2025-11-22T13:19:00Z

--- a/src/content/official-repos/miniflux.yaml
+++ b/src/content/official-repos/miniflux.yaml
@@ -1,4 +1,5 @@
 name: Miniflux
+url: https://github.com/rose-pine/miniflux
 category: browser
 stargazersCount: 0
 updatedAt: 2026-02-02T23:05:46Z

--- a/src/content/official-repos/mintty.yaml
+++ b/src/content/official-repos/mintty.yaml
@@ -1,4 +1,5 @@
 name: MinTTY
+url: https://github.com/rose-pine/mintty
 category: terminal
 stargazersCount: 3
 updatedAt: 2025-11-05T14:47:00Z

--- a/src/content/official-repos/misskey.yaml
+++ b/src/content/official-repos/misskey.yaml
@@ -1,4 +1,5 @@
 name: Misskey
+url: https://github.com/rose-pine/misskey
 category: browser
 stargazersCount: 17
 updatedAt: 2026-05-18T09:24:36Z

--- a/src/content/official-repos/mona.yaml
+++ b/src/content/official-repos/mona.yaml
@@ -1,4 +1,5 @@
 name: Mona
+url: https://github.com/rose-pine/mona
 category: social
 stargazersCount: 2
 updatedAt: 2025-11-05T14:47:02Z

--- a/src/content/official-repos/neovim.yaml
+++ b/src/content/official-repos/neovim.yaml
@@ -1,4 +1,5 @@
 name: Neovim
+url: https://github.com/rose-pine/neovim
 category: editor
 stargazersCount: 3045
 updatedAt: 2026-06-28T09:17:00Z

--- a/src/content/official-repos/ninjabrain-bot.yaml
+++ b/src/content/official-repos/ninjabrain-bot.yaml
@@ -1,4 +1,5 @@
 name: Ninjabrain Bot
+url: https://github.com/rose-pine/ninjabrain-bot
 category: editor
 stargazersCount: 2
 updatedAt: 2025-11-05T14:50:21Z

--- a/src/content/official-repos/nomacs.yaml
+++ b/src/content/official-repos/nomacs.yaml
@@ -1,4 +1,5 @@
 name: nomacs
+url: https://github.com/rose-pine/nomacs
 category: editor
 stargazersCount: 1
 updatedAt: 2026-02-22T03:39:22Z

--- a/src/content/official-repos/obs.yaml
+++ b/src/content/official-repos/obs.yaml
@@ -1,4 +1,5 @@
 name: OBS Studio
+url: https://github.com/rose-pine/obs
 category: editor
 stargazersCount: 7
 updatedAt: 2026-04-02T18:30:07Z

--- a/src/content/official-repos/obsidian.yaml
+++ b/src/content/official-repos/obsidian.yaml
@@ -1,4 +1,5 @@
 name: Obsidian
+url: https://github.com/rose-pine/obsidian
 category: editor
 stargazersCount: 28
 updatedAt: 2026-06-07T15:44:06Z

--- a/src/content/official-repos/ollama-webui.yaml
+++ b/src/content/official-repos/ollama-webui.yaml
@@ -1,4 +1,5 @@
 name: Ollama WebUI
+url: https://github.com/rose-pine/ollama-webui
 category: browser
 stargazersCount: 14
 updatedAt: 2026-06-01T21:15:48Z

--- a/src/content/official-repos/onecommander.yaml
+++ b/src/content/official-repos/onecommander.yaml
@@ -1,4 +1,5 @@
 name: OneCommander
+url: https://github.com/rose-pine/onecommander
 category: editor
 stargazersCount: 5
 updatedAt: 2026-03-28T11:52:39Z

--- a/src/content/official-repos/pleroma.yaml
+++ b/src/content/official-repos/pleroma.yaml
@@ -1,4 +1,5 @@
 name: Pleroma
+url: https://github.com/rose-pine/pleroma
 category: social
 stargazersCount: 7
 updatedAt: 2025-11-22T13:17:34Z

--- a/src/content/official-repos/polybar.yaml
+++ b/src/content/official-repos/polybar.yaml
@@ -1,4 +1,5 @@
 name: Polybar
+url: https://github.com/rose-pine/polybar
 category: system
 stargazersCount: 7
 updatedAt: 2025-12-03T13:15:04Z

--- a/src/content/official-repos/prism.yaml
+++ b/src/content/official-repos/prism.yaml
@@ -1,4 +1,5 @@
 name: Prism
+url: https://github.com/rose-pine/prism
 category: library
 stargazersCount: 9
 updatedAt: 2025-11-05T14:50:30Z

--- a/src/content/official-repos/pureref.yaml
+++ b/src/content/official-repos/pureref.yaml
@@ -1,4 +1,5 @@
 name: PureRef
+url: https://github.com/rose-pine/pureref
 category: editor
 stargazersCount: 3
 updatedAt: 2026-03-16T12:55:09Z

--- a/src/content/official-repos/pygments.yaml
+++ b/src/content/official-repos/pygments.yaml
@@ -1,4 +1,5 @@
 name: Pygments
+url: https://github.com/rose-pine/pygments
 category: library
 stargazersCount: 3
 updatedAt: 2026-03-02T08:58:05Z

--- a/src/content/official-repos/pywal.yaml
+++ b/src/content/official-repos/pywal.yaml
@@ -1,4 +1,5 @@
 name: pywal
+url: https://github.com/rose-pine/pywal
 category: library
 stargazersCount: 2
 updatedAt: 2026-01-02T19:12:34Z

--- a/src/content/official-repos/qbittorrent.yaml
+++ b/src/content/official-repos/qbittorrent.yaml
@@ -1,4 +1,5 @@
 name: qBittorrent
+url: https://github.com/rose-pine/qbittorrent
 category: editor
 stargazersCount: 19
 updatedAt: 2026-05-18T09:24:52Z

--- a/src/content/official-repos/qterminal.yaml
+++ b/src/content/official-repos/qterminal.yaml
@@ -1,4 +1,5 @@
 name: QTerminal
+url: https://github.com/rose-pine/qterminal
 category: terminal
 stargazersCount: 4
 updatedAt: 2025-11-05T14:50:36Z

--- a/src/content/official-repos/r-markdown.yaml
+++ b/src/content/official-repos/r-markdown.yaml
@@ -1,4 +1,5 @@
 name: R Markdown
+url: https://github.com/rose-pine/r-markdown
 category: editor
 stargazersCount: 7
 updatedAt: 2025-11-05T14:50:37Z

--- a/src/content/official-repos/razer-cli.yaml
+++ b/src/content/official-repos/razer-cli.yaml
@@ -1,4 +1,5 @@
 name: Razer CLI
+url: https://github.com/rose-pine/razer-cli
 category: terminal
 stargazersCount: 6
 updatedAt: 2025-11-05T14:50:38Z

--- a/src/content/official-repos/revolt.yaml
+++ b/src/content/official-repos/revolt.yaml
@@ -1,4 +1,5 @@
 name: Revolt
+url: https://github.com/rose-pine/revolt
 category: browser
 stargazersCount: 3
 updatedAt: 2025-11-05T14:50:39Z

--- a/src/content/official-repos/rio-terminal.yaml
+++ b/src/content/official-repos/rio-terminal.yaml
@@ -1,4 +1,5 @@
 name: Rio Terminal
+url: https://github.com/rose-pine/rio-terminal
 category: terminal
 stargazersCount: 9
 updatedAt: 2025-11-05T14:50:39Z

--- a/src/content/official-repos/rmpc.yaml
+++ b/src/content/official-repos/rmpc.yaml
@@ -1,4 +1,5 @@
 name: rmpc
+url: https://github.com/rose-pine/rmpc
 category: terminal
 stargazersCount: 1
 updatedAt: 2026-06-07T16:31:35Z

--- a/src/content/official-repos/roblox-studio.yaml
+++ b/src/content/official-repos/roblox-studio.yaml
@@ -1,4 +1,5 @@
 name: Roblox Studio
+url: https://github.com/rose-pine/roblox-studio
 category: editor
 stargazersCount: 3
 updatedAt: 2026-05-28T03:01:23Z

--- a/src/content/official-repos/rofi.yaml
+++ b/src/content/official-repos/rofi.yaml
@@ -1,4 +1,5 @@
 name: Rofi
+url: https://github.com/rose-pine/rofi
 category: system
 stargazersCount: 28
 updatedAt: 2026-06-11T21:57:32Z

--- a/src/content/official-repos/rstudio.yaml
+++ b/src/content/official-repos/rstudio.yaml
@@ -1,4 +1,5 @@
 name: Rstudio
+url: https://github.com/rose-pine/rstudio
 category: editor
 stargazersCount: 2
 updatedAt: 2026-04-15T14:04:37Z

--- a/src/content/official-repos/sharex.yaml
+++ b/src/content/official-repos/sharex.yaml
@@ -1,4 +1,5 @@
 name: ShareX
+url: https://github.com/rose-pine/sharex
 category: editor
 stargazersCount: 7
 updatedAt: 2026-06-26T04:32:16Z

--- a/src/content/official-repos/slack.yaml
+++ b/src/content/official-repos/slack.yaml
@@ -1,4 +1,5 @@
 name: Slack
+url: https://github.com/rose-pine/slack
 category: browser
 stargazersCount: 25
 updatedAt: 2026-06-22T18:34:41Z

--- a/src/content/official-repos/speedcrunch.yaml
+++ b/src/content/official-repos/speedcrunch.yaml
@@ -1,4 +1,5 @@
 name: SpeedCrunch
+url: https://github.com/rose-pine/speedcrunch
 category: editor
 stargazersCount: 2
 updatedAt: 2025-12-01T18:31:40Z

--- a/src/content/official-repos/st.yaml
+++ b/src/content/official-repos/st.yaml
@@ -1,4 +1,5 @@
 name: st
+url: https://github.com/rose-pine/st
 category: terminal
 stargazersCount: 10
 updatedAt: 2026-04-30T00:24:04Z

--- a/src/content/official-repos/starship.yaml
+++ b/src/content/official-repos/starship.yaml
@@ -1,4 +1,5 @@
 name: Starship
+url: https://github.com/rose-pine/starship
 category: terminal
 stargazersCount: 74
 updatedAt: 2026-05-29T08:27:29Z

--- a/src/content/official-repos/startpage.yaml
+++ b/src/content/official-repos/startpage.yaml
@@ -1,4 +1,5 @@
 name: Startpage
+url: https://github.com/rose-pine/startpage
 category: browser
 stargazersCount: 31
 updatedAt: 2026-04-16T12:51:05Z

--- a/src/content/official-repos/steam-os.yaml
+++ b/src/content/official-repos/steam-os.yaml
@@ -1,4 +1,5 @@
 name: SteamOS
+url: https://github.com/rose-pine/steam-os
 category: system
 stargazersCount: 3
 updatedAt: 2026-03-21T00:57:38Z

--- a/src/content/official-repos/sublime-text.yaml
+++ b/src/content/official-repos/sublime-text.yaml
@@ -1,4 +1,5 @@
 name: Sublime Text
+url: https://github.com/rose-pine/sublime-text
 category: editor
 stargazersCount: 32
 updatedAt: 2026-05-12T03:51:33Z

--- a/src/content/official-repos/sumatrapdf.yaml
+++ b/src/content/official-repos/sumatrapdf.yaml
@@ -1,4 +1,5 @@
 name: SumatraPDF
+url: https://github.com/rose-pine/sumatrapdf
 category: editor
 stargazersCount: 1
 updatedAt: 2026-02-28T23:32:56Z

--- a/src/content/official-repos/superfile.yaml
+++ b/src/content/official-repos/superfile.yaml
@@ -1,4 +1,5 @@
 name: superfile
+url: https://github.com/rose-pine/superfile
 category: terminal
 stargazersCount: 1
 updatedAt: 2026-01-24T16:47:53Z

--- a/src/content/official-repos/surfingkeys.yaml
+++ b/src/content/official-repos/surfingkeys.yaml
@@ -1,4 +1,5 @@
 name: Surfingkeys
+url: https://github.com/rose-pine/surfingkeys
 category: browser
 stargazersCount: 32
 updatedAt: 2026-04-30T03:09:41Z

--- a/src/content/official-repos/swaync.yaml
+++ b/src/content/official-repos/swaync.yaml
@@ -1,4 +1,5 @@
 name: Sway Notification Center
+url: https://github.com/rose-pine/swaync
 category: system
 stargazersCount: 24
 updatedAt: 2026-06-05T22:08:11Z

--- a/src/content/official-repos/tabby.yaml
+++ b/src/content/official-repos/tabby.yaml
@@ -1,4 +1,5 @@
 name: Tabby
+url: https://github.com/rose-pine/tabby
 category: terminal
 stargazersCount: 0
 updatedAt: 2026-04-30T18:08:18Z

--- a/src/content/official-repos/tailwind-css.yaml
+++ b/src/content/official-repos/tailwind-css.yaml
@@ -1,4 +1,5 @@
 name: Tailwind CSS
+url: https://github.com/rose-pine/tailwind-css
 category: library
 stargazersCount: 30
 updatedAt: 2026-05-16T07:16:57Z

--- a/src/content/official-repos/tauon.yaml
+++ b/src/content/official-repos/tauon.yaml
@@ -1,4 +1,5 @@
 name: Tauon Music Box
+url: https://github.com/rose-pine/tauon
 category: social
 stargazersCount: 4
 updatedAt: 2025-11-05T14:51:01Z

--- a/src/content/official-repos/terminal.app.yaml
+++ b/src/content/official-repos/terminal.app.yaml
@@ -1,4 +1,5 @@
 name: Terminal.app
+url: https://github.com/rose-pine/terminal.app
 category: terminal
 stargazersCount: 45
 updatedAt: 2026-06-08T23:45:40Z

--- a/src/content/official-repos/terminator.yaml
+++ b/src/content/official-repos/terminator.yaml
@@ -1,4 +1,5 @@
 name: Terminator
+url: https://github.com/rose-pine/terminator
 category: terminal
 stargazersCount: 3
 updatedAt: 2025-11-28T04:18:02Z

--- a/src/content/official-repos/termite.yaml
+++ b/src/content/official-repos/termite.yaml
@@ -1,4 +1,5 @@
 name: Termite
+url: https://github.com/rose-pine/termite
 category: terminal
 stargazersCount: 2
 updatedAt: 2025-11-05T14:51:03Z

--- a/src/content/official-repos/termusic.yaml
+++ b/src/content/official-repos/termusic.yaml
@@ -1,4 +1,5 @@
 name: termusic
+url: https://github.com/rose-pine/termusic
 category: terminal
 stargazersCount: 0
 updatedAt: 2025-11-07T15:37:25Z

--- a/src/content/official-repos/termux.yaml
+++ b/src/content/official-repos/termux.yaml
@@ -1,4 +1,5 @@
 name: Termux
+url: https://github.com/rose-pine/termux
 category: terminal
 stargazersCount: 20
 updatedAt: 2025-12-21T00:49:18Z

--- a/src/content/official-repos/tidal.yaml
+++ b/src/content/official-repos/tidal.yaml
@@ -1,4 +1,5 @@
 name: TIDAL
+url: https://github.com/rose-pine/tidal
 category: browser
 stargazersCount: 9
 updatedAt: 2025-12-22T21:16:02Z

--- a/src/content/official-repos/tm-theme.yaml
+++ b/src/content/official-repos/tm-theme.yaml
@@ -1,4 +1,5 @@
 name: TextMate
+url: https://github.com/rose-pine/tm-theme
 category: editor
 stargazersCount: 18
 updatedAt: 2026-06-22T15:22:09Z

--- a/src/content/official-repos/tmux.yaml
+++ b/src/content/official-repos/tmux.yaml
@@ -1,7 +1,8 @@
 name: tmux
+url: https://github.com/rose-pine/tmux
 category: terminal
-stargazersCount: 268
-updatedAt: 2026-06-22T18:34:46Z
+stargazersCount: 269
+updatedAt: 2026-06-29T12:05:36Z
 contributors:
   - name: mrs4ndman
     url: https://github.com/mrs4ndman

--- a/src/content/official-repos/tym.yaml
+++ b/src/content/official-repos/tym.yaml
@@ -1,4 +1,5 @@
 name: tym
+url: https://github.com/rose-pine/tym
 category: terminal
 stargazersCount: 1
 updatedAt: 2025-11-05T14:51:09Z

--- a/src/content/official-repos/typora.yaml
+++ b/src/content/official-repos/typora.yaml
@@ -1,4 +1,5 @@
 name: Typora
+url: https://github.com/rose-pine/typora
 category: editor
 stargazersCount: 7
 updatedAt: 2025-11-05T14:51:10Z

--- a/src/content/official-repos/typst.yaml
+++ b/src/content/official-repos/typst.yaml
@@ -1,4 +1,5 @@
 name: Typst
+url: https://github.com/rose-pine/typst
 category: terminal
 stargazersCount: 11
 updatedAt: 2026-05-22T16:15:23Z

--- a/src/content/official-repos/ulauncher.yaml
+++ b/src/content/official-repos/ulauncher.yaml
@@ -1,4 +1,5 @@
 name: Ulauncher
+url: https://github.com/rose-pine/ulauncher
 category: system
 stargazersCount: 4
 updatedAt: 2025-11-05T14:51:13Z

--- a/src/content/official-repos/userstyles.yaml
+++ b/src/content/official-repos/userstyles.yaml
@@ -1,4 +1,5 @@
 name: Userstyles
+url: https://github.com/rose-pine/userstyles
 category: browser
 stargazersCount: 48
 updatedAt: 2026-06-27T09:58:01Z

--- a/src/content/official-repos/vim.yaml
+++ b/src/content/official-repos/vim.yaml
@@ -1,4 +1,5 @@
 name: Vim
+url: https://github.com/rose-pine/vim
 category: editor
 stargazersCount: 52
 updatedAt: 2026-06-26T19:10:20Z

--- a/src/content/official-repos/vimium-c.yaml
+++ b/src/content/official-repos/vimium-c.yaml
@@ -1,4 +1,5 @@
 name: Vimium C
+url: https://github.com/rose-pine/vimium-c
 category: browser
 stargazersCount: 13
 updatedAt: 2025-11-05T14:51:16Z

--- a/src/content/official-repos/vivaldi.yaml
+++ b/src/content/official-repos/vivaldi.yaml
@@ -1,4 +1,5 @@
 name: Vivaldi
+url: https://github.com/rose-pine/vivaldi
 category: browser
 stargazersCount: 8
 updatedAt: 2025-12-01T04:29:35Z

--- a/src/content/official-repos/vscode.yaml
+++ b/src/content/official-repos/vscode.yaml
@@ -1,4 +1,5 @@
 name: Visual Studio Code
+url: https://github.com/rose-pine/vscode
 category: editor
 stargazersCount: 596
 updatedAt: 2026-06-28T04:30:41Z

--- a/src/content/official-repos/wallpapers.yaml
+++ b/src/content/official-repos/wallpapers.yaml
@@ -1,7 +1,8 @@
 name: Wallpapers
+url: https://github.com/rose-pine/wallpapers
 category: system
-stargazersCount: 416
-updatedAt: 2026-06-28T13:47:15Z
+stargazersCount: 419
+updatedAt: 2026-06-30T18:45:33Z
 contributors:
   - name: ThatOneCalculator
     url: https://github.com/ThatOneCalculator

--- a/src/content/official-repos/waybar.yaml
+++ b/src/content/official-repos/waybar.yaml
@@ -1,4 +1,5 @@
 name: Waybar
+url: https://github.com/rose-pine/waybar
 category: system
 stargazersCount: 61
 updatedAt: 2026-06-25T07:42:27Z

--- a/src/content/official-repos/whoogle.yaml
+++ b/src/content/official-repos/whoogle.yaml
@@ -1,4 +1,5 @@
 name: Whoogle
+url: https://github.com/rose-pine/whoogle
 category: browser
 stargazersCount: 7
 updatedAt: 2025-11-05T14:51:21Z

--- a/src/content/official-repos/windows-terminal.yaml
+++ b/src/content/official-repos/windows-terminal.yaml
@@ -1,4 +1,5 @@
 name: Windows Terminal
+url: https://github.com/rose-pine/windows-terminal
 category: terminal
 stargazersCount: 113
 updatedAt: 2026-06-27T10:53:34Z

--- a/src/content/official-repos/writefreely.yaml
+++ b/src/content/official-repos/writefreely.yaml
@@ -1,4 +1,5 @@
 name: WriteFreely
+url: https://github.com/rose-pine/writefreely
 category: browser
 stargazersCount: 6
 updatedAt: 2026-06-03T18:08:33Z

--- a/src/content/official-repos/xfce-terminal.yaml
+++ b/src/content/official-repos/xfce-terminal.yaml
@@ -1,4 +1,5 @@
 name: XFCE4 Terminal
+url: https://github.com/rose-pine/xfce-terminal
 category: terminal
 stargazersCount: 18
 updatedAt: 2026-04-07T18:08:39Z

--- a/src/content/official-repos/xresources.yaml
+++ b/src/content/official-repos/xresources.yaml
@@ -1,4 +1,5 @@
 name: Xresources
+url: https://github.com/rose-pine/xresources
 category: terminal
 stargazersCount: 7
 updatedAt: 2025-12-18T20:31:19Z

--- a/src/content/official-repos/yazi.yaml
+++ b/src/content/official-repos/yazi.yaml
@@ -1,4 +1,5 @@
 name: Yazi
+url: https://github.com/rose-pine/yazi
 category: terminal
 stargazersCount: 17
 updatedAt: 2026-06-24T03:21:05Z

--- a/src/content/official-repos/zed.yaml
+++ b/src/content/official-repos/zed.yaml
@@ -1,4 +1,5 @@
 name: Zed
+url: https://github.com/rose-pine/zed
 category: editor
 stargazersCount: 62
 updatedAt: 2026-06-16T18:21:30Z

--- a/src/content/official-repos/zellij.yaml
+++ b/src/content/official-repos/zellij.yaml
@@ -1,4 +1,5 @@
 name: Zellij
+url: https://github.com/rose-pine/zellij
 category: terminal
 stargazersCount: 46
 updatedAt: 2026-06-23T11:35:52Z

--- a/src/content/official-repos/zen-browser.yaml
+++ b/src/content/official-repos/zen-browser.yaml
@@ -1,4 +1,5 @@
 name: Zen Browser
+url: https://github.com/rose-pine/zen-browser
 category: browser
 stargazersCount: 30
 updatedAt: 2026-06-26T04:35:54Z

--- a/src/content/official-repos/zer0bin.yaml
+++ b/src/content/official-repos/zer0bin.yaml
@@ -1,4 +1,5 @@
 name: zer0bin
+url: https://github.com/rose-pine/zer0bin
 category: browser
 stargazersCount: 2
 updatedAt: 2025-11-05T14:51:31Z

--- a/src/data.ts
+++ b/src/data.ts
@@ -35,7 +35,7 @@ function normalizeOfficial(entry: CollectionEntry<"officialRepos">): Repo {
 	return {
 		slug: entry.id,
 		name,
-		url: `https://github.com/rose-pine/${entry.id}`,
+		url: d.url,
 		tags,
 		contributors: d.contributors.map((c) => ({
 			...c,


### PR DESCRIPTION
This commit fixes a bug where "Terminal.app" would be slugified by Astro, causing the built URL to include "terminalapp" (no period).