### PR TITLE
detect language

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,13 +13,19 @@ import { readdirSync, writeFileSync } from "fs";
 function localeTypes() {
 	function generate() {
 		const dir = new URL("src/locales/", import.meta.url);
-		const type = readdirSync(dir)
-			.filter((f) => f.endsWith(".ts")) // find .ts files
-			.map((f) => `"${f.slice(0, -3)}"`) // strip file extension
-			.join(" | "); // join with union delimiter
+		const files = readdirSync(dir)
+			.filter((f) => f.endsWith(".ts"))
+			.map((f) => f.slice(0, -3));
+
+		const type = files.map((f) => `"${f}"`).join(" | ");
 		writeFileSync(
 			new URL("src/types/locale.gen.ts", import.meta.url),
 			`// Auto-generated — do not edit\nexport type Locale = ${type};\n`,
+		);
+
+		writeFileSync(
+			new URL("netlify/edge-functions/locales.json", import.meta.url),
+			JSON.stringify(files, null, "\t") + "\n",
 		);
 	}
 	return {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  command = "pnpm run build"
+  publish = "dist"
+
+[dev]
+  command = "pnpm run dev"
+
+[[edge_functions]]
+  function = "geo-redirect"
+  path = "/"

--- a/netlify/edge-functions/geo-redirect.ts
+++ b/netlify/edge-functions/geo-redirect.ts
@@ -1,0 +1,71 @@
+import type { Context } from "@netlify/edge-functions";
+import locales from "./locales.json" with { type: "json" };
+
+const defaultLocale = "en";
+
+export function detectPreferredLang(header: string): string {
+	const entries = header
+		.split(",")
+		.map((part) => {
+			const [lang, q] = part.split(";");
+			return {
+				lang: lang.trim(),
+				quality: q ? parseFloat(q.split("=")[1]) : 1,
+			};
+		})
+		.filter(({ quality }) => quality > 0)
+		.filter(
+			({ lang }) =>
+				locales.includes(lang) || locales.includes(lang.split("-")[0]),
+		)
+		.sort((a, b) => b.quality - a.quality);
+
+	if (entries.length === 0) {
+		return "en";
+	}
+
+	const best = entries[0].lang;
+	return locales.includes(best) ? best : best.split("-")[0];
+}
+
+function setLocaleCookie(context: Context, locale: string) {
+	context.cookies.set({
+		name: "locale",
+		value: locale,
+		path: "/",
+		maxAge: 60 * 60 * 24 * 365,
+		sameSite: "Lax",
+	});
+}
+
+export default async (request: Request, context: Context) => {
+	const url = new URL(request.url);
+	const pathLocale = url.pathname.split("/")[1];
+	const langParam = url.searchParams.get("lang");
+
+	if (langParam && locales.includes(langParam)) {
+		setLocaleCookie(context, langParam);
+		const returnTo = url.searchParams.get("returnTo") || "/";
+		const prefix = langParam === defaultLocale ? "" : `/${langParam}`;
+		return Response.redirect(`${url.origin}${prefix}${returnTo}`, 302);
+	}
+
+	if (locales.includes(pathLocale)) {
+		setLocaleCookie(context, pathLocale);
+		return context.next();
+	}
+
+	const cookieLocale = context.cookies.get("locale");
+	const locale =
+		cookieLocale && locales.includes(cookieLocale)
+			? cookieLocale
+			: detectPreferredLang(request.headers.get("accept-language") ?? "");
+
+	setLocaleCookie(context, locale);
+
+	return locale === defaultLocale
+		? context.next()
+		: Response.redirect(`${url.origin}/${locale}${url.pathname}`, 302);
+};
+
+export const config = { path: "/" };

--- a/netlify/edge-functions/locales.json
+++ b/netlify/edge-functions/locales.json
@@ -1,0 +1,18 @@
+[
+	"ar",
+	"ca",
+	"cs",
+	"de",
+	"en",
+	"es",
+	"fr",
+	"id",
+	"it",
+	"ko",
+	"nl",
+	"pt-BR",
+	"sv",
+	"tr",
+	"uk",
+	"zh-CN"
+]

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"devDependencies": {
 		"@astrojs/check": "^0.9.9",
+		"@netlify/edge-functions": "^3.0.8",
 		"@octokit/rest": "^22.0.1",
 		"prettier": "^3.9.5",
 		"prettier-plugin-astro": "^0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@astrojs/netlify':
         specifier: ^8.1.2
-        version: 8.1.2(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
+        version: 8.1.2(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(jiti@2.7.0)(rollup@4.62.2)(supports-color@7.2.0)(yaml@2.9.0)
       '@astrojs/svelte':
         specifier: 9.0.1
-        version: 9.0.1(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.6(@typescript-eslint/types@8.64.0))(typescript@6.0.3)(yaml@2.9.0)
+        version: 9.0.1(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.6(@typescript-eslint/types@8.64.0))(typescript@6.0.3)(yaml@2.9.0)
       '@tailwindcss/typography':
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.3)
@@ -22,7 +22,7 @@ importers:
         version: 4.3.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       astro:
         specifier: 7.1.1
-        version: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
+        version: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
       svelte:
         specifier: ^5.56.6
         version: 5.56.6(@typescript-eslint/types@8.64.0)
@@ -33,6 +33,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.5)(typescript@6.0.3)
+      '@netlify/edge-functions':
+        specifier: ^3.0.8
+        version: 3.0.8
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -4749,15 +4752,15 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  '@astrojs/netlify@8.1.2(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)':
+  '@astrojs/netlify@8.1.2(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(jiti@2.7.0)(rollup@4.62.2)(supports-color@7.2.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/underscore-redirects': 1.0.3
-      '@netlify/blobs': 10.7.9
+      '@netlify/blobs': 10.7.9(supports-color@7.2.0)
       '@netlify/functions': 5.3.0
-      '@netlify/vite-plugin': 2.12.9(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-      '@vercel/nft': 1.10.2(rollup@4.62.2)
-      astro: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
+      '@netlify/vite-plugin': 2.12.9(rollup@4.62.2)(supports-color@7.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vercel/nft': 1.10.2(rollup@4.62.2)(supports-color@7.2.0)
+      astro: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
       esbuild: 0.28.1
       tinyglobby: 0.2.17
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -4804,10 +4807,10 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/svelte@9.0.1(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.6(@typescript-eslint/types@8.64.0))(typescript@6.0.3)(yaml@2.9.0)':
+  '@astrojs/svelte@9.0.1(@types/node@26.1.1)(astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(svelte@5.56.6(@typescript-eslint/types@8.64.0))(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.6(@typescript-eslint/types@8.64.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-      astro: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
+      astro: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
       svelte: 5.56.6(@typescript-eslint/types@8.64.0)
       svelte2tsx: 0.7.58(svelte@5.56.6(@typescript-eslint/types@8.64.0))(typescript@6.0.3)
       typescript: 6.0.3
@@ -5368,11 +5371,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mapbox/node-pre-gyp@2.0.3':
+  '@mapbox/node-pre-gyp@2.0.3(supports-color@7.2.0)':
     dependencies:
       consola: 3.4.2
       detect-libc: 2.1.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.8.5
@@ -5408,10 +5411,10 @@ snapshots:
 
   '@netlify/binary-info@1.0.0': {}
 
-  '@netlify/blobs@10.7.9':
+  '@netlify/blobs@10.7.9(supports-color@7.2.0)':
     dependencies:
       '@netlify/dev-utils': 4.4.6
-      '@netlify/otel': 6.0.3
+      '@netlify/otel': 6.0.3(supports-color@7.2.0)
       '@netlify/runtime-utils': 2.3.0
     transitivePeerDependencies:
       - supports-color
@@ -5470,19 +5473,19 @@ snapshots:
       semver: 7.8.5
       tmp-promise: 3.0.3
 
-  '@netlify/dev@4.18.9(rollup@4.62.2)':
+  '@netlify/dev@4.18.9(rollup@4.62.2)(supports-color@7.2.0)':
     dependencies:
       '@netlify/ai': 0.4.2
-      '@netlify/blobs': 10.7.9
+      '@netlify/blobs': 10.7.9(supports-color@7.2.0)
       '@netlify/config': 24.6.0
       '@netlify/database-dev': 0.10.1
       '@netlify/dev-utils': 4.4.6
       '@netlify/edge-functions-dev': 1.0.22
-      '@netlify/functions-dev': 1.3.1(rollup@4.62.2)
+      '@netlify/functions-dev': 1.3.1(rollup@4.62.2)(supports-color@7.2.0)
       '@netlify/headers': 2.1.11
-      '@netlify/images': 1.3.10(@netlify/blobs@10.7.9)
+      '@netlify/images': 1.3.10(@netlify/blobs@10.7.9(supports-color@7.2.0))
       '@netlify/redirects': 3.1.13
-      '@netlify/runtime': 4.1.25
+      '@netlify/runtime': 4.1.25(supports-color@7.2.0)
       '@netlify/static': 3.1.10
       ulid: 3.0.2
     transitivePeerDependencies:
@@ -5551,15 +5554,15 @@ snapshots:
     dependencies:
       '@netlify/types': 2.8.0
 
-  '@netlify/functions-dev@1.3.1(rollup@4.62.2)':
+  '@netlify/functions-dev@1.3.1(rollup@4.62.2)(supports-color@7.2.0)':
     dependencies:
-      '@netlify/blobs': 10.7.9
+      '@netlify/blobs': 10.7.9(supports-color@7.2.0)
       '@netlify/dev-utils': 4.4.6
       '@netlify/functions': 5.3.0
-      '@netlify/zip-it-and-ship-it': 14.7.1(rollup@4.62.2)
+      '@netlify/zip-it-and-ship-it': 14.7.1(rollup@4.62.2)(supports-color@7.2.0)
       cron-parser: 4.9.0
       decache: 4.6.2
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(supports-color@7.2.0)
       is-stream: 4.0.1
       jwt-decode: 4.0.0
       lambda-local: 2.2.0
@@ -5591,9 +5594,9 @@ snapshots:
     dependencies:
       '@netlify/headers-parser': 9.0.3
 
-  '@netlify/images@1.3.10(@netlify/blobs@10.7.9)':
+  '@netlify/images@1.3.10(@netlify/blobs@10.7.9(supports-color@7.2.0))':
     dependencies:
-      ipx: 3.1.1(@netlify/blobs@10.7.9)
+      ipx: 3.1.1(@netlify/blobs@10.7.9(supports-color@7.2.0))
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5618,11 +5621,11 @@ snapshots:
 
   '@netlify/open-api@2.57.0': {}
 
-  '@netlify/otel@6.0.3':
+  '@netlify/otel@6.0.3(supports-color@7.2.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)(supports-color@7.2.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
@@ -5645,9 +5648,9 @@ snapshots:
 
   '@netlify/runtime-utils@2.3.0': {}
 
-  '@netlify/runtime@4.1.25':
+  '@netlify/runtime@4.1.25(supports-color@7.2.0)':
     dependencies:
-      '@netlify/blobs': 10.7.9
+      '@netlify/blobs': 10.7.9(supports-color@7.2.0)
       '@netlify/cache': 3.4.8
       '@netlify/runtime-utils': 2.3.0
       '@netlify/types': 2.8.0
@@ -5664,9 +5667,9 @@ snapshots:
 
   '@netlify/types@2.8.0': {}
 
-  '@netlify/vite-plugin@2.12.9(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@netlify/vite-plugin@2.12.9(rollup@4.62.2)(supports-color@7.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
-      '@netlify/dev': 4.18.9(rollup@4.62.2)
+      '@netlify/dev': 4.18.9(rollup@4.62.2)(supports-color@7.2.0)
       '@netlify/dev-utils': 4.4.6
       dedent: 1.7.2
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -5698,13 +5701,13 @@ snapshots:
       - supports-color
       - uploadthing
 
-  '@netlify/zip-it-and-ship-it@14.7.1(rollup@4.62.2)':
+  '@netlify/zip-it-and-ship-it@14.7.1(rollup@4.62.2)(supports-color@7.2.0)':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       '@netlify/binary-info': 1.0.0
       '@netlify/serverless-functions-api': 2.16.0
-      '@vercel/nft': 0.29.4(rollup@4.62.2)
+      '@vercel/nft': 0.29.4(rollup@4.62.2)(supports-color@7.2.0)
       archiver: 7.0.1
       common-path-prefix: 3.0.0
       copy-file: 11.1.0
@@ -5722,7 +5725,7 @@ snapshots:
       normalize-path: 3.0.0
       p-map: 7.0.5
       path-exists: 5.0.0
-      precinct: 12.3.2
+      precinct: 12.3.2(supports-color@7.2.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.7
       semver: 7.8.5
@@ -5830,12 +5833,12 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.0)(supports-color@7.2.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.217.0
       import-in-the-middle: 3.2.0
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6243,11 +6246,11 @@ snapshots:
       '@types/node': 26.1.1
     optional: true
 
-  '@typescript-eslint/project-service@8.64.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.64.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -6258,13 +6261,13 @@ snapshots:
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.64.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.64.0(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -6280,9 +6283,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vercel/nft@0.29.4(rollup@4.62.2)':
+  '@vercel/nft@0.29.4(rollup@4.62.2)(supports-color@7.2.0)':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3
+      '@mapbox/node-pre-gyp': 2.0.3(supports-color@7.2.0)
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -6299,9 +6302,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/nft@1.10.2(rollup@4.62.2)':
+  '@vercel/nft@1.10.2(rollup@4.62.2)(supports-color@7.2.0)':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3
+      '@mapbox/node-pre-gyp': 2.0.3(supports-color@7.2.0)
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -6537,7 +6540,7 @@ snapshots:
 
   ast-module-types@6.0.2: {}
 
-  astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0):
+  astro@7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@netlify/blobs@10.7.9(supports-color@7.2.0))(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
       '@astrojs/internal-helpers': 0.10.1
@@ -6586,7 +6589,7 @@ snapshots:
       tinyglobby: 0.2.17
       ultrahtml: 1.7.0
       unifont: 0.7.4
-      unstorage: 1.17.5(@netlify/blobs@10.7.9)
+      unstorage: 1.17.5(@netlify/blobs@10.7.9(supports-color@7.2.0))
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
@@ -6918,9 +6921,11 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decache@4.6.2:
     dependencies:
@@ -6986,16 +6991,16 @@ snapshots:
 
   detective-stylus@5.0.1: {}
 
-  detective-typescript@14.1.2(typescript@5.9.3):
+  detective-typescript@14.1.2(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.3)
       ast-module-types: 6.0.2
       node-source-walk: 7.0.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  detective-vue2@2.3.0(typescript@5.9.3):
+  detective-vue2@2.3.0(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
       '@dependents/detective-less': 5.0.3
       '@vue/compiler-sfc': 3.5.40
@@ -7003,7 +7008,7 @@ snapshots:
       detective-sass: 6.0.2
       detective-scss: 5.0.2
       detective-stylus: 5.0.1
-      detective-typescript: 14.1.2(typescript@5.9.3)
+      detective-typescript: 14.1.2(supports-color@7.2.0)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7298,9 +7303,9 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
+  extract-zip@2.0.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -7594,10 +7599,10 @@ snapshots:
 
   http-shutdown@1.2.2: {}
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7628,7 +7633,7 @@ snapshots:
       hasown: 2.0.4
       side-channel: 1.1.1
 
-  ipx@3.1.1(@netlify/blobs@10.7.9):
+  ipx@3.1.1(@netlify/blobs@10.7.9(supports-color@7.2.0)):
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       citty: 0.1.6
@@ -7644,7 +7649,7 @@ snapshots:
       sharp: 0.34.5
       svgo: 4.0.2
       ufo: 1.6.4
-      unstorage: 1.17.5(@netlify/blobs@10.7.9)
+      unstorage: 1.17.5(@netlify/blobs@10.7.9(supports-color@7.2.0))
       xss: 1.0.15
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -8358,7 +8363,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  precinct@12.3.2:
+  precinct@12.3.2(supports-color@7.2.0):
     dependencies:
       '@dependents/detective-less': 5.0.3
       commander: 12.1.0
@@ -8369,8 +8374,8 @@ snapshots:
       detective-sass: 6.0.2
       detective-scss: 5.0.2
       detective-stylus: 5.0.1
-      detective-typescript: 14.1.2(typescript@5.9.3)
-      detective-vue2: 2.3.0(typescript@5.9.3)
+      detective-typescript: 14.1.2(supports-color@7.2.0)(typescript@5.9.3)
+      detective-vue2: 2.3.0(supports-color@7.2.0)(typescript@5.9.3)
       module-definition: 6.0.2
       node-source-walk: 7.0.2
       postcss: 8.5.19
@@ -8505,9 +8510,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -9149,7 +9154,7 @@ snapshots:
     dependencies:
       normalize-path: 2.1.1
 
-  unstorage@1.17.5(@netlify/blobs@10.7.9):
+  unstorage@1.17.5(@netlify/blobs@10.7.9(supports-color@7.2.0)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -9160,7 +9165,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
     optionalDependencies:
-      '@netlify/blobs': 10.7.9
+      '@netlify/blobs': 10.7.9(supports-color@7.2.0)
 
   untun@0.1.3:
     dependencies:

--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -114,7 +114,7 @@ let socialItems = [
 								let localisedName = displayNames.of(lang) ?? name;
 								return (
 									<a
-										href={`${translatePath(getUrlWithoutLocale(Astro.url), lang)}?lang=${lang}`}
+										href={`/?lang=${lang}&returnTo=${getUrlWithoutLocale(Astro.url)}`}
 										class="dropdown-item"
 									>
 										<div class="flex flex-col leading-tight">

--- a/test/detect-preferred-lang.ts
+++ b/test/detect-preferred-lang.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { detectPreferredLang } from "../netlify/edge-functions/geo-redirect.ts";
+
+const acceptLanguages = [
+	// prefers "en-US", we provide "en"
+	{ value: "en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7", wants: "en" },
+	// prefers "it" then "en"
+	{ value: "it;q=0.9,en;q=0.8", wants: "it" },
+	// prefers "fr", not in order of priority
+	{ value: "fr;q=0.9,en;q=0.8", wants: "fr" },
+	// prefers "fr" (fallback to any language)
+	{ value: "fr;q=0.9,*;q=0.5", wants: "fr" },
+	// prefers "sd" (unsupported), fallback to "nl"
+	{ value: "sd;q=0.9,nl;q=0.8,zh-CN;q=0.7,zh;q=0.6", wants: "nl" },
+	// prefers "es" then "pt" (no "q" defaults to 1)
+	{ value: "pt;q=0.9,es", wants: "es" },
+	// prefers "en", does NOT prefer "sv"
+	{ value: "sv;q=0,en;q=0.9", wants: "en" },
+	// does NOT prefer "sv", fallback to "en"
+	{ value: "sv;q=0", wants: "en" },
+	// prefers "ca" (poorly formatted)
+	{ value: "ca;Q=0.7 , en;q=0.6", wants: "ca" },
+];
+
+test("detect preferred language from Accept-Language", (t) => {
+	for (const { value, wants } of acceptLanguages) {
+		t.test(value, () => assert.equal(detectPreferredLang(value), wants));
+	}
+});


### PR DESCRIPTION
This PR automatically redirects to the user's preferred language (or closest match, falling back to English). Selecting a language from the picker overrides this via a cookie.

The behaviour is quite lovely, but does have some nuance:

1. Even though `astro dev` still works, the automatic redirect does not work and selecting a different language from the picker no longer maintains the current page. The fix is to use `netlify dev` to emulate edge functions and such.
2. Edge functions and the dependency on Netlify. Not my favourite, but the user experience may justify the overhead.