### PR TITLE
feat: add lich theme

### DIFF
--- a/src/content/community-repos/lich.yaml
+++ b/src/content/community-repos/lich.yaml
@@ -1,0 +1,9 @@
+name: lich
+url: https://github.com/omartelo/rose-pine-lich
+tags:
+  - terminal
+  - agents
+contributors:
+  - name: martelo
+    url: https://github.com/omartelo
+category: terminal


### PR DESCRIPTION
## Summary

Adds the [Rosé Pine theme for lich](https://github.com/omartelo/rose-pine-lich) to the community repos list.

[lich](https://github.com/omartelo/lich) is a terminal-first harness for coding with AI agents — a desktop app that wraps projects, agent sessions and git worktrees around real terminals. The theme repository ships all three variants (Rosé Pine, Moon, Dawn), each recolouring both the app interface and the xterm terminal palette.

## Entry

`src/content/community-repos/lich.yaml`:

```yaml
name: lich
url: https://github.com/omartelo/rose-pine-lich
tags:
  - terminal
  - agents
contributors:
  - name: martelo
    url: https://github.com/omartelo
category: terminal
```

## Checklist

- [x] Colours follow the [Rosé Pine palette](https://rosepinetheme.com/palette) — base, surface, overlay, highlights, muted/subtle/text and all six accents, unmodified
- [x] All three variants supported
- [x] Terminal ANSI mapping matches the official Rosé Pine terminal spec
- [x] Repo is public
- [x] `category` is one of the values in `src/data/categories.json`
- [x] YAML validates against the `communityRepos` schema in `src/content.config.ts`