### PR TITLE
i18n: add Italian translation for docs, colophon & highlights

### DIFF
--- a/src/content/guides/en/contributing.md
+++ b/src/content/guides/en/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-description: Report bugs, suggest features and contribute code or documenation.
+description: Report bugs, suggest features and contribute code or documentation.
 author: mvllow
 publishedAt: 2021-01-30T12:00:00-06:00
 updatedAt: 2021-01-30T12:00:00-06:00

--- a/src/content/guides/it/code-of-conduct.md
+++ b/src/content/guides/it/code-of-conduct.md
@@ -1,0 +1,85 @@
+---
+title: Codice di Condotta
+description: Principi generali per contribuire all'organizzazione Rosé Pine.
+author: wawaverse
+publishedAt: 2026-08-05T12:00:00-06:00
+updatedAt: 2026-08-05T12:00:00-06:00
+---
+
+## Il Nostro Impegno
+
+Nell'interesse della promozione di un ambiente aperto e accogliente, noi contributori e manutentori ci impegnamo a rendere la partecipazione alla nostra comunità un'esperienza libera da molestie per tutti, indipendentemente dall'età, corporatura, disabilità visibile o meno, etnia, caratteristiche sessuali, identità ed espressione di genere, livello di esperienza, istruzione, stato socio-economico, nazionalità, aspetto, razza, religione o identità e orientamento sessuale.
+
+Noi ci impegniamo ad agire ed interagire per costruire una comunità aperta, accogliente, diversificata, inclusiva e sana.
+
+## I nostri Standard
+
+Esempi di comportamenti che contribuiscono alla creazione di un ambiente positivo per la nostra comunità:
+
+* Dimostrare empatia e gentilezza verso le altre persone
+* Rispettare le opinioni, i punti di vista ed esperienze differenti
+* Fornire, con garbo, critiche costruttive
+* Prendersi la responsabilità di quanto sostenuto e scusarsi verso le persone colpite dai nostri sbagli, imparando da queste esperienze
+* Concentrarsi non su ciò che è meglio per noi come individui, ma su ciò che è meglio per la comunità
+
+Esempi di comportamento inaccettabile:
+
+* L'uso di linguaggio o immagini sessualizzate e l'attenzione sessuale o avance indesiderate
+* Comportamenti da troll, commenti offensivi e attacchi personali o politici
+* Molestie in pubblico o in privato
+* Pubblicazione di informazioni private altrui, ad esempio un indirizzo postale o elettronico, senza autorizzazione esplicita
+* Altri comportamenti che potrebbero ragionevolmente essere considerati inappropriati in un contesto professionale
+
+## Adempimento e Responsabilità
+
+Le persone alla guida della comunità sono responsabili del chiarimento e dell'applicazione degli standard di comportamento accettabili e sono tenuti a intraprendere azioni correttive appropriate ed eque in risposta a qualsiasi caso di comportamento inaccettabile, minaccioso, offensivo o dannoso.
+
+Le persone alla guida della comunità hanno il diritto e la responsabilità di rimuovere, modificare o rifiutare commenti, commit, codice, modifiche dei wiki, issue e altri contributi non allineati a questo Codice di Comportamento, comunicando le ragioni dell'intervento di moderazione quando opportuno.
+
+## Scopo
+
+Questo Codice di Comportamento si applica sia all'interno degli spazi della comunità che negli spazi pubblici quando un individuo rappresenta la sua comunità. Esempi di rappresentanza della nostra comunità includono l'uso di un indirizzo e-mail ufficiale del progetto, la pubblicazione tramite un account ufficiale attraverso social media o la funzione di rappresentante designato ad un evento online o offline.
+
+## Applicazione
+
+I casi di comportamento abusivo, molesto o altrimenti inaccettabile possono essere presentate contattando i responsabili dell'applicazione di questo Codice di Condotta della comunità all'indirizzo [INSERISCI INDIRIZZO EMAIL]. Tutti i reclami saranno prontamente esaminati ed indagati.
+
+Tutte le guide della comunità sono obbligate a mantenere la riservatezza della persona che ha riportato il caso.
+
+## Linee guida all'applicazione
+
+Le guide della comunità seguiranno queste linee guida per determinare le azioni correttive contro azioni che ritengono violare questo Codice di Condotta:
+
+### 1. Correzione
+
+**Impatto nella comunità**: Uso di linguaggio inappropriato o altri comportamenti giudicati non professionali o ostili nella community.
+
+**Conseguenze**: Un avviso scritto in forma privata dalle guide della comunità, spiegando la natura della violazione e perché il comportamento era inappopriato. Pubbliche scuse potrebbero essere richieste.
+
+### 2. Avviso
+
+**Impatto nella comunità**: Una violazione dopo un episodio avvenuto o una serie di azioni negative.
+
+**Conseguenze**: Un avviso per il comportamento perpetrato. Nessuna comunicazione per un periodo di tempo specificato con le persone coinvolte, incluse quelle che applicano il Codice di Condotta. Questo comprende l'inibizione alla partecipazione negli spazi della comunità come canali esterni quali i social media. Violare questi termini può portare ad una espulsione temporanea o permanente.
+
+### 3. Espulsione temporanea
+
+**Impatto nella comunità**: Una grave violazione agli standard della comunità, incluso mantenere un comportamento inappropriato.
+
+**Conseguenze**: Espulsione temporanea per un periodo di tempo specificato a qualsiasi sorta di interazione o comunicazione con la comunità. Durante questo periodo non è permesso nessun dialogo pubblico o privato con le persone coinvolte, comprese coloro che applicano il Codice di Condotta. Violare questi termini può portare ad una espulsione permanente.
+
+### 4. Espulsione permanente
+
+**Impatto nella comunità**: Dimostrare sistematicamente di violare gli standard della comunità, inclusa la ripetezione di comportamenti inappropriati, molestie o aggressioni individuali o denigrazione di gruppi di individui.
+
+**Conseguenze**: Espulsione permanente da ogni interazione pubblica della comunità.
+
+## Attribuzione
+
+Questo Codice di Condotta è adattato dal [Contributor Covenant][homepage], versione 2.0, disponibile all'indirizzo https://www.contributor-covenant.org/version/2/0/code-of-conduct.html
+
+Le linee guida all'applicazione sono state ispirate dal [codice di condotta di Mozilla](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+Per riposte a domande comuni riguardo questo codice di condotta, controlla le domande frequenti al link https://www.contributor-covenant.org/faq. Le traduzioni sono disponibili al link https://www.contributor-covenant.org/translations.

--- a/src/content/guides/it/code-of-conduct.md
+++ b/src/content/guides/it/code-of-conduct.md
@@ -42,7 +42,7 @@ Questo Codice di Comportamento si applica sia all'interno degli spazi della comu
 
 ## Applicazione
 
-I casi di comportamento abusivo, molesto o altrimenti inaccettabile possono essere presentate contattando i responsabili dell'applicazione di questo Codice di Condotta della comunità all'indirizzo [INSERISCI INDIRIZZO EMAIL]. Tutti i reclami saranno prontamente esaminati ed indagati.
+I casi di comportamento abusivo, molesto o altrimenti inaccettabile possono essere presentate contattando i responsabili dell'applicazione di questo Codice di Condotta della comunità all'indirizzo hi@rosepinetheme.com. Tutti i reclami saranno prontamente esaminati ed indagati.
 
 Tutte le guide della comunità sono obbligate a mantenere la riservatezza della persona che ha riportato il caso.
 

--- a/src/content/guides/it/contributing.md
+++ b/src/content/guides/it/contributing.md
@@ -1,0 +1,72 @@
+---
+title: Contribuire
+description: Segnala bug, suggerisci feature e contribuisci con codice o documentazione.
+author: wawaverse
+publishedAt: 2026-08-05T12:00:00-06:00
+updatedAt: 2026-08-05T12:00:00-06:00
+---
+
+Questo progetto è mantenuto a beneficio della community e siamo grati per qualsiasi contributo che aiuti a migliorarlo. Chiediamo ai contributori di:
+
+- Essere gentili con tutti 💛
+- Seguire il [Codice di Condotta](/create/code-of-conduct)
+- Rispettare il tempo e l'impegno dei manutentori e degli altri contributori
+
+## Cosa contribuire
+
+Accogliamo con favore e apprezziamo sia i contributi di codice che quelli non legati al codice, tra cui:
+
+- Correzione errori di battitura
+- Miglioramenti alla documentazione
+- Revisioni delle pull request
+- Richieste di feature
+- Opinioni & suggerimenti
+
+Anche i cambiamenti più piccoli possono aiutarci a liberare tempo per la manutenzione generale e a promuovere un'esperienza positiva, funzionale e accessibile per tutti ✨
+
+## Segnalazione di bug e richieste di funzionalità
+
+Prima di aprire un issue, cerca tra le issue esistenti, comprese quelle chiuse.
+
+**Se esiste già:**
+
+- Usa le [reazioni](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) per dare visibilità all'issue
+- Riserva i commenti a informazioni specifiche che potrebbero aiutare a risolvere il problema
+
+**Altrimenti:**
+
+Apri un issue contenente quanto segue:
+
+_Segnalazioni di bug:_
+
+- Più contesto possibile sul problema e su come e quando si verifica
+- Passaggi per riprodurre il problema
+- Report di crash, screenshot o log di errore, se possibile
+- Versioni del software, se applicabile
+
+_Richieste di feature:_
+
+- Descrizione della feature o della modifica richiesta
+- Motivazioni o contesto a supporto, se opportuno
+
+Non possiamo garantire che le issue vengano risolte immediatamente, ma apprezziamo profondamente i suggerimenti e le segnalazioni e prendiamo in seria considerazione tutte le richieste.
+
+## Contributi al codice e alla documentazione
+
+> Se stai aggiungendo un nuovo tema, usa il nostro [template](https://github.com/rose-pine/rose-pine-template)
+
+**Implement your changes:**
+
+- Non aggiungere metafile non legati al progetto. Consulta il [global gitignore](https://gist.github.com/subfuzion/db7f57fff2fb6998a16c) per le pratiche migliori
+- Fai una fork della repositoria ed esegui il commit delle modifiche su un branch tematico con un nome descrittivo
+- Se possibile, raggruppa le modifiche in commit e branch logici e mirati
+- Attieniti al formato del codice esistente, ad esempio messaggi di commit in minuscolo
+
+**Invia una PR:**
+
+- Invia una pull request alla repositoria principale con le tue modifiche e qualsiasi informazione di supporto, spiegazione o contesto che ritieni opportuno
+- Se il tuo contributo è collegato a un'issue, fai riferimento ad essa nella descrizione della PR, ad es. `fixes #123`
+
+## Grazie
+
+Grazie per il tuo supporto e buon lavoro! 🌸

--- a/src/content/guides/it/contributing.md
+++ b/src/content/guides/it/contributing.md
@@ -1,5 +1,5 @@
 ---
-title: Contribuire
+title: Guida ai contributi
 description: Segnala bug, suggerisci feature e contribuisci con codice o documentazione.
 author: wawaverse
 publishedAt: 2026-08-05T12:00:00-06:00

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -52,9 +52,15 @@ export default defineLocale({
 		"themes.search_placeholder": "Cerca temi...",
 		"themes.search_focus_cue": "Premi / per focalizzare",
 
+		"colophon.title": "Crediti",
+		"colophon.description": "Le radici del nostro giardino.",
+
 		"photography.title": "Fotografie",
 		"photography.description":
 			"Se non ti fermi un attimo, potresti perdere una vista perfetta.",
+
+		"made-with.title": "Realizzati con Rosé Pine",
+		"made-with.description": "Momenti salienti dalla community.",
 
 		"palette.title": "Tavolozza",
 		"palette.description": "Colori curati, pensati per ispirare.",

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -10,6 +10,7 @@ export default defineLocale({
 		"nav.palette": "Tavolozza",
 		"nav.create": "Crea",
 		"nav.collection.photography": "Fotografie",
+		"nav.collection.made-with": "Realizzati con Rosé Pine",
 		"nav.language": "Lingua",
 		"nav.resources": "Risorse",
 		"nav.resource.create": "Crea un tema",


### PR DESCRIPTION
- Added Italian Code of Conduct in `/src/content/guides/it/code-of-conduct.md` [(Contributor Covenant 2.0)](https://www.contributor-covenant.org/it/version/2/0/code_of_conduct/code_of_conduct.md)
- Translated `/src/content/guides/en/contributing.md` to Italian
- Translated Colophon & "Made with Rosé Pine" to italian in `/src/locales/it.ts`
- Fixed minor typo in` /src/content/guides/en/contributing.md`
```diff
- description: Report bugs, suggest features and contribute code or documenation.
+ description: Report bugs, suggest features and contribute code or documentation.
```