### PR TITLE
ci: bump `actions/setup-node` to v7

### DIFF
--- a/.github/workflows/data.yaml
+++ b/.github/workflows/data.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 11
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
I noticed that the CI was using an outdated major version for the `actions/setup-node` GitHub action :)