### PR TITLE
Spanish translation

### DIFF
--- a/src/content/authors/mrodant.yaml
+++ b/src/content/authors/mrodant.yaml
@@ -1,0 +1,3 @@
+name: "mrodant"
+image: "https://avatars.githubusercontent.com/mrodant"
+url: "https://codeberg.org/mrodant"

--- a/src/content/guides/es/add-a-translation.md
+++ b/src/content/guides/es/add-a-translation.md
@@ -1,0 +1,82 @@
+---
+title: Añade una traducción
+description: Un paso a paso para internacionalizar el sitio web de Rosé Pine.
+author: mrodant
+publishedAt: 2026-08-30T16:00:00+02:00
+updatedAt: 2026-08-30T16:00:00+02:00
+---
+
+Los idiomas son preciosos y nos complace que quieras compartir el tuyo con el mundo. Más abajo, te enseñamos a traducir distintas partes del sitio web y sus artículos.
+
+Aunque no es estrictamente necesario, tener un entorno de desarrollo local te permitirá ver en tiempo real los cambios que realices. Alternativamente, puedes [hacer cambios directamente desde Github](https://github.com/rose-pine/rose-pine-site).
+
+## Prepara el entorno de desarrollo
+
+1. Haz un *fork* y clona el [sitio web de Rosé Pine](https://github.com/rose-pine/rose-pine-site).
+2. Instala [Node.js](https://nodejs.org/es/download) y [pnpm](https://pnpm.io/es/installation) siguiendo sus manuales oficiales.
+3. Inicia el servidor de desarrollo con `pnpm dev` para tener una vista previa en tiempo real del contenido.
+
+## Traduce el sitio web
+
+Copia el archivo con el texto en inglés y renómbralo con el código de tu idioma:
+
+```diff
+  src/locales/en.ts
++ src/locales/sd.ts
+```
+
+Actualiza `name` dentro de `config` con el nombre de tu idioma, y añade las traducciones:
+
+```diff
+  import { defineLocale } from "../utilities/i18n";
+
+  export default defineLocale({
+    config: {
+-     name: "English",
++     name: "Sindarin",
+    },
+    translations: {
+-     "nav.language": "Language",
++     "nav.language": "Lamb",
+      ...
+    },
+  });
+```
+
+Las frases no traducidas se mostrarán en inglés por defecto.
+
+## Traduce las guías
+
+Usando como referencia la versión en inglés, crea la guía a traducir:
+
+```diff
+  src/content/guides/en/create-a-theme.md
++ src/content/guides/sd/create-a-theme.md
+```
+
+Observa que hemos creado una carpeta `sd` para nuestro ejemplo, el sindarin, mientras que el nombre del archivo con el texto es el mismo.
+
+Actualiza el *frontmatter*—metadatos al principio del archivo, entre dos líneas formadas por `---`—con un título, una descripción, autoría y fechas.
+
+```
+---
+title: <título>
+description: <descripción>
+author: <nombre de usuario>
+publishedAt: 2025-11-09T12:00:00-06:00
+updatedAt: 2025-11-09T12:00:00-06:00
+---
+```
+
+El nombre de usuario se corresponderá con un archivo en la carpeta `src/content/authors/`, así que asegúrate de añadirte, por ejemplo:
+
+```diff
+// src/content/authors/<nombre de usuario>.yaml
++ name: "<nombre>"
++ image: "https://avatars.githubusercontent.com/<nombre de usuario>"
++ url: "https://ejemplo.com"
+```
+
+## Solicita incorporar tus cambios
+
+Crea una *pull request* en [rose-pine/rose-pine-site](https://github.com/rose-pine/rose-pine-site). La revisaremos y, una vez integradas las modificaciones, ¡te compartiremos nuestro aprecio por hacer Rosé Pine un poquito más accesible!

--- a/src/content/guides/es/code-of-conduct.md
+++ b/src/content/guides/es/code-of-conduct.md
@@ -1,0 +1,141 @@
+---
+title: Código de Conducta
+description: Principios generales para contribuir a la organización Rosé Pine.
+author: mrodant
+publishedAt: 2026-08-30T18:00:00+02:00
+updatedAt: 2026-08-30T18:00:00+02:00
+---
+
+## Nuestro compromiso
+
+Como miembros, contribuyentes y administradores, nos comprometemos a hacer de la
+participación en nuestra comunidad una experiencia libre de acoso para todo el
+mundo, independientemente de la edad, dimensión corporal, minusvalía visible o
+invisible, etnicidad, características sexuales, identidad y expresión de género,
+nivel de experiencia, educación, nivel socio-económico, nacionalidad, apariencia
+personal, raza, religión, o identidad u orientación sexual.
+
+Nos comprometemos a actuar e interactuar de maneras que contribuyan a una
+comunidad abierta, acogedora, diversa, inclusiva y sana.
+
+## Nuestros estándares
+
+Ejemplos de comportamiento que contribuyen a crear un ambiente positivo para
+nuestra comunidad:
+
+* Demostrar empatía y amabilidad ante otras personas
+* Respeto a diferentes opiniones, puntos de vista y experiencias
+* Dar y aceptar adecuadamente retroalimentación constructiva
+* Aceptar la responsabilidad y disculparse ante quienes se vean afectados por
+nuestros errores, aprendiendo de la experiencia
+* Centrarse en lo que sea mejor no sólo a nivel individual, sino para la
+comunidad en general
+
+Ejemplos de comportamiento inaceptable:
+
+* El uso de lenguaje o imágenes sexualizadas, y aproximaciones o atenciones
+sexuales de cualquier tipo
+* Comentarios despectivos (_trolling_), insultantes o derogatorios, y ataques
+personales o políticos
+* El acoso en público o privado
+* Publicar información privada de otras personas, tales como direcciones físicas
+o de correo electrónico, sin su permiso explícito
+* Otras conductas que puedan ser razonablemente consideradas como inapropiadas
+en un entorno profesional
+
+## Aplicación de las responsabilidades
+
+Los administradores de la comunidad son responsables de aclarar y hacer cumplir
+nuestros estándares de comportamiento aceptable y tomarán acciones apropiadas y
+correctivas de forma justa en respuesta a cualquier comportamiento que
+consideren inapropiado, amenazante, ofensivo o dañino.
+
+Los administradores de la comunidad tendrán el derecho y la responsabilidad de
+eliminar, editar o rechazar comentarios, _commits_, código, ediciones de páginas
+de wiki, _issues_ y otras contribuciones que no se alineen con este Código de
+Conducta, y comunicarán las razones para sus decisiones de moderación cuando sea
+apropiado.
+
+## Alcance
+
+Este código de conducta aplica tanto a espacios del proyecto como a espacios
+públicos donde un individuo esté en representación del proyecto o comunidad.
+Ejemplos de esto incluyen el uso de la cuenta oficial de correo electrónico,
+publicaciones a través de las redes sociales oficiales, o presentaciones con
+personas designadas en eventos en línea o no.
+
+## Aplicación
+
+Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán
+ser reportadas a los administradores de la comunidad responsables del
+cumplimiento a través de [INSERTAR MÉTODO DE CONTACTO]. Todas las quejas serán
+evaluadas e investigadas de una manera puntual y justa.
+
+Todos los administradores de la comunidad están obligados a respetar la
+privacidad y la seguridad de quienes reporten incidentes.
+
+## Guías de Aplicación
+
+Los administradores de la comunidad seguirán estas Guías de Impacto en la
+Comunidad para determinar las consecuencias de cualquier acción que juzguen como
+un incumplimiento de este Código de Conducta:
+
+### 1. Corrección
+
+**Impacto en la Comunidad**: El uso de lenguaje inapropiado u otro
+comportamiento considerado no profesional o no acogedor en la comunidad.
+
+**Consecuencia**: Un aviso escrito y privado por parte de los administradores de
+la comunidad, proporcionando claridad alrededor de la naturaleza de este
+incumplimiento y una explicación de por qué el comportamiento es inaceptable.
+Una disculpa pública podría ser solicitada.
+
+### 2. Aviso
+
+**Impacto en la Comunidad**: Un incumplimiento causado por un único incidente o
+por una cadena de acciones.
+
+**Consecuencia**: Un aviso con consecuencias por comportamiento prolongado. No
+se interactúa con las personas involucradas, incluyendo interacción no
+solicitada con quienes se encuentran aplicando el Código de Conducta, por un
+periodo especificado de tiempo. Esto incluye evitar las interacciones en
+espacios de la comunidad, así como a través de canales externos como las redes
+sociales. Incumplir estos términos puede conducir a una expulsión temporal o
+permanente.
+
+### 3. Expulsión temporal
+
+**Impacto en la Comunidad**: Una serie de incumplimientos de los estándares de
+la comunidad, incluyendo comportamiento inapropiado continuo.
+
+**Consecuencia**: Una expulsión temporal de cualquier forma de interacción o
+comunicación pública con la comunidad durante un intervalo de tiempo
+especificado. No se permite interactuar de manera pública o privada con las
+personas involucradas, incluyendo interacciones no solicitadas con quienes se
+encuentran aplicando el Código de Conducta, durante este periodo. Incumplir
+estos términos puede conducir a una expulsión permanente.
+
+### 4. Expulsión permanente
+
+**Impacto en la Comunidad**: Demostrar un patrón sistemático de incumplimientos
+de los estándares de la comunidad, incluyendo conductas inapropiadas prolongadas
+en el tiempo, acoso de individuos, o agresiones o menosprecio a grupos de
+individuos.
+
+**Consecuencia**: Una expulsión permanente de cualquier tipo de interacción
+pública con la comunidad del proyecto.
+
+## Atribución
+
+Este Código de Conducta es una adaptación del [Contributor Covenant][homepage],
+versión 2.0, disponible en
+https://www.contributor-covenant.org/es/version/2/0/code_of_conduct.html
+
+Las Guías de Impacto en la Comunidad están inspiradas en la
+[escalera de aplicación del código de conducta de Mozilla](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+Para respuestas a las preguntas frecuentes de este código de conducta, consulta
+las FAQ en https://www.contributor-covenant.org/faq. Hay traducciones
+disponibles en https://www.contributor-covenant.org/translations

--- a/src/content/guides/es/code-of-conduct.md
+++ b/src/content/guides/es/code-of-conduct.md
@@ -68,7 +68,7 @@ personas designadas en eventos en línea o no.
 
 Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán
 ser reportadas a los administradores de la comunidad responsables del
-cumplimiento a través de [INSERTAR MÉTODO DE CONTACTO]. Todas las quejas serán
+cumplimiento a través de hola@rosepinetheme.com. Todas las quejas serán
 evaluadas e investigadas de una manera puntual y justa.
 
 Todos los administradores de la comunidad están obligados a respetar la

--- a/src/content/guides/es/code-of-conduct.md
+++ b/src/content/guides/es/code-of-conduct.md
@@ -23,25 +23,25 @@ comunidad abierta, acogedora, diversa, inclusiva y sana.
 Ejemplos de comportamiento que contribuyen a crear un ambiente positivo para
 nuestra comunidad:
 
-* Demostrar empatía y amabilidad ante otras personas
-* Respeto a diferentes opiniones, puntos de vista y experiencias
-* Dar y aceptar adecuadamente retroalimentación constructiva
-* Aceptar la responsabilidad y disculparse ante quienes se vean afectados por
-nuestros errores, aprendiendo de la experiencia
-* Centrarse en lo que sea mejor no sólo a nivel individual, sino para la
-comunidad en general
+- Demostrar empatía y amabilidad ante otras personas
+- Respeto a diferentes opiniones, puntos de vista y experiencias
+- Dar y aceptar adecuadamente retroalimentación constructiva
+- Aceptar la responsabilidad y disculparse ante quienes se vean afectados por
+  nuestros errores, aprendiendo de la experiencia
+- Centrarse en lo que sea mejor no sólo a nivel individual, sino para la
+  comunidad en general
 
 Ejemplos de comportamiento inaceptable:
 
-* El uso de lenguaje o imágenes sexualizadas, y aproximaciones o atenciones
-sexuales de cualquier tipo
-* Comentarios despectivos (_trolling_), insultantes o derogatorios, y ataques
-personales o políticos
-* El acoso en público o privado
-* Publicar información privada de otras personas, tales como direcciones físicas
-o de correo electrónico, sin su permiso explícito
-* Otras conductas que puedan ser razonablemente consideradas como inapropiadas
-en un entorno profesional
+- El uso de lenguaje o imágenes sexualizadas, y aproximaciones o atenciones
+  sexuales de cualquier tipo
+- Comentarios despectivos (_trolling_), insultantes o derogatorios, y ataques
+  personales o políticos
+- El acoso en público o privado
+- Publicar información privada de otras personas, tales como direcciones físicas
+  o de correo electrónico, sin su permiso explícito
+- Otras conductas que puedan ser razonablemente consideradas como inapropiadas
+  en un entorno profesional
 
 ## Aplicación de las responsabilidades
 

--- a/src/content/guides/es/contributing.md
+++ b/src/content/guides/es/contributing.md
@@ -22,7 +22,7 @@ Recibimos con los brazos abiertos tanto aportaciones de código como de otros ti
 - Peticiones de nueva funcionalidad
 - Opiniones y sugerencias
 
-Hasta la aportación más pequeña nos ayuda a liberar algo de nuestro tiempo para mantenimiento general y promoción de una experiencia positiva, funcional y accesible para todo el mundo ✨
+Hasta la aportación más pequeña nos ayuda a liberar algo de nuestro tiempo para mantenimiento general y fomento de una experiencia positiva, funcional y accesible para todo el mundo ✨
 
 ## Informes de errores y nueva funcionalidad
 

--- a/src/content/guides/es/contributing.md
+++ b/src/content/guides/es/contributing.md
@@ -1,0 +1,73 @@
+---
+title: Contribuye
+description: Informa sobre errores, sugiere funcionalidad nueva y contribuye código o documentación.
+author: mrodant
+publishedAt: 2026-08-30T17:00:00+02:00
+updatedAt: 2026-08-30T17:00:00+02:00
+---
+
+Este proyecto se mantiene para el beneficio de la comunidad, y agradecemos cualquier contribución que ayude a mejorarlo. Pedimos a quien contribuya:
+
+- Ser amable con todo el mundo 💛
+- Seguir el [Código de Conducta](/create/code-of-conduct)
+- Respetar el tiempo y esfuerzo del equipo detrás y el resto de contribuyentes
+
+## Qué contribuir
+
+Recibimos con los brazos abiertos tanto aportaciones de código como de otros tipos, incluyendo:
+
+- Correcciones de ortografía
+- Mejoras en la documentación
+- Revisiones de *pull requests*
+- Peticiones de nueva funcionalidad
+- Opiniones y sugerencias
+
+Hasta la aportación más pequeña nos ayuda a liberar algo de nuestro tiempo para mantenimiento general y promoción de una experiencia positiva, funcional y accesible para todo el mundo ✨
+
+## Informes de errores y nueva funcionalidad
+
+Antes de abrir un *issue*, busca entre los existentes, incluyendo los cerrados.
+
+**Si ya existe:**
+
+- Utiliza las [reacciones](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) de Github para promoverlo
+- Reserva los comentarios para información concreta que ayude a abordar el problema
+
+**En otro caso:**
+
+Abre un *issue* que contenga lo siguiente:
+
+_Informes de errores:_
+
+- Contexto del problema y cómo y cuándo ocurre
+- Pasos para reproducir el problema
+- Informes de error, capturas de pantalla, o registros de uso si procede
+- Versión del software si procede
+
+_Peticiones de funcionalidad:_
+
+- Descripción del cambio o la nueva función
+- Razonamiento o contexto de la misma si procede
+
+No podemos garantizar que los problemas se resuelvan inmediatamente, pero apreciamos enormemente sugerencias e informes y consideramos con seriedad todas las peticiones.
+
+## Aportaciones de código y documentación
+
+> Si vas a añadir un nuevo tema, utiliza nuestra [plantilla](https://github.com/rose-pine/rose-pine-template)
+
+**Implementa tus cambios:**
+
+- No añadas archivos no relacionados con el proyecto. Véase [global gitignore](https://gist.github.com/subfuzion/db7f57fff2fb6998a16c) para buenas prácticas generales
+- Crea un *fork* del repositorio y realiza los *commits* con los cambios en una rama con un nombre descriptivo
+- En la medida de lo posible, agrupa los cambios en ramas y *commits* dedicados y lógicos
+- Adhiérete a un formato de código existente, por ejemplo mensajes de *commit* en minúscula
+
+**Envía una PR:**
+
+- Envía una *pull request* al repositorio principal con tus cambios y cualquier información adicional, explicación o contexto que estimes oportunos
+
+- Si la *pull request* está relacionada con un *issue* existente, referéncialo en la descripción de la misma, por ejemplo `arregla #123`
+
+## Gracias
+
+¡Gracias por tu apoyo y felices contribuciones! 🌸

--- a/src/content/guides/es/create-a-theme.md
+++ b/src/content/guides/es/create-a-theme.md
@@ -9,12 +9,13 @@ updatedAt: 2026-08-29T22:00:00+02:00
 Desde Rosé Pine sugerimos abordar con creatividad y libertad nuestra limitada paleta de colores en los temas de la comunidad. Para quienes prefieran un enfoque más estructurado y guiado, existe la opción de crear un tema oficial a ser incluido en la organización Rosé Pine en Github, desde la cual el equipo ayudará dentro de lo posible.
 
 Comienza con nuestra [plantilla de repositorio](https://github.com/rose-pine/rose-pine-template) como base para tu nuevo tema.
+
 ```sh
 gh repo create mi-app --public --clone --template rose-pine/rose-pine-template
 ```
 
 Utiliza nuestra herramienta de compilación, [bloom](https://github.com/rose-pine/rose-pine-bloom), para acceder con facilidad a nuestra paleta e incluir las tres variantes. Crea una plantilla a partir de un archivo de tema existente con `bloom init <nombre-de-archivo>`.
 
-Una vez desarrolado, puedes [presentar tu tema](/new) como oficial o de la comunidad. Para uno oficial, te invitaremos a la organización en Github para transferirlo a la misma. Este será añadido automáticamente a la página web. Para uno de la comunidad, el único requerimiento es rellenar el formulario anterior.
+Una vez desarrollado, puedes [presentar tu tema](/new) como oficial o de la comunidad. Para uno oficial, te invitaremos a la organización en Github para transferirlo a la misma. Este será añadido automáticamente a la página web. Para uno de la comunidad, el único requerimiento es rellenar el formulario anterior.
 
 Gracias por compartir tu trabajo con la comunidad, ¡estamos deseando ver qué creas!

--- a/src/content/guides/es/create-a-theme.md
+++ b/src/content/guides/es/create-a-theme.md
@@ -1,0 +1,20 @@
+---
+title: Crea un tema
+description: Una guía completa para llevar Rosé Pine a tus plataformas favoritas.
+author: mrodant
+publishedAt: 2026-08-29T22:00:00+02:00
+updatedAt: 2026-08-29T22:00:00+02:00
+---
+
+Desde Rosé Pine sugerimos abordar con creatividad y libertad nuestra limitada paleta de colores en los temas de la comunidad. Para quienes prefieran un enfoque más estructurado y guiado, existe la opción de crear un tema oficial a ser incluido en la organización Rosé Pine en Github, desde la cual el equipo ayudará dentro de lo posible.
+
+Comienza con nuestra [plantilla de repositorio](https://github.com/rose-pine/rose-pine-template) como base para tu nuevo tema.
+```sh
+gh repo create mi-app --public --clone --template rose-pine/rose-pine-template
+```
+
+Utiliza nuestra herramienta de compilación, [bloom](https://github.com/rose-pine/rose-pine-bloom), para acceder con facilidad a nuestra paleta e incluir las tres variantes. Crea una plantilla a partir de un archivo de tema existente con `bloom init <nombre-de-archivo>`.
+
+Una vez desarrolado, puedes [presentar tu tema](/new) como oficial o de la comunidad. Para uno oficial, te invitaremos a la organización en Github para transferirlo a la misma. Este será añadido automáticamente a la página web. Para uno de la comunidad, el único requerimiento es rellenar el formulario anterior.
+
+Gracias por compartir tu trabajo con la comunidad, ¡estamos deseando ver qué creas!

--- a/src/content/palette/es/base.md
+++ b/src/content/palette/es/base.md
@@ -1,0 +1,8 @@
+---
+name: Base
+description: Fondo principal
+---
+
+- Fondo del editor / documento
+- Paneles principales de la aplicación, como barras laterales o árboles de archivos
+- Color sobre el que componer elementos semitransparentes

--- a/src/content/palette/es/foam.md
+++ b/src/content/palette/es/foam.md
@@ -5,5 +5,5 @@ description: Pozas de marea
 
 - Señales informativas
 - Anotaciones de tipos, tipos del lenguaje
-- Nombres de etiqueta (HTML, XML...)
+- Nombres de etiquetas (HTML, XML...)
 - En la terminal, azul y azul claro

--- a/src/content/palette/es/foam.md
+++ b/src/content/palette/es/foam.md
@@ -1,0 +1,9 @@
+---
+name: Foam
+description: Pozas de marea
+---
+
+- Señales informativas
+- Anotaciones de tipos, tipos del lenguaje
+- Nombres de etiqueta (HTML, XML...)
+- En la terminal, azul y azul claro

--- a/src/content/palette/es/gold.md
+++ b/src/content/palette/es/gold.md
@@ -1,0 +1,9 @@
+---
+name: Gold
+description: Té de limón una mañana de verano
+---
+
+- Avisos, advertencias
+- Literales de cadena
+- Subrayado de resultados de búsqueda (en conjunción con [Base](/palette/base))
+- En la terminal, amarillo y amarillo claro

--- a/src/content/palette/es/highlight-high.md
+++ b/src/content/palette/es/highlight-high.md
@@ -1,0 +1,8 @@
+---
+name: Highlight High
+description: Subrayado de alto contraste
+---
+
+- Bordes, divisores visuales, separadores
+- Fondo del cursor
+- Fondo de los resultados de búsqueda / búsqueda incremental

--- a/src/content/palette/es/highlight-low.md
+++ b/src/content/palette/es/highlight-low.md
@@ -1,0 +1,7 @@
+---
+name: Highlight Low
+description: Subrayado de bajo contraste
+---
+
+- Fondo de la línea del cursor, fondo de la línea actual
+- Separación sutil de filas en listas y tablas

--- a/src/content/palette/es/highlight-med.md
+++ b/src/content/palette/es/highlight-med.md
@@ -1,0 +1,7 @@
+---
+name: Highlight Med
+description: Subrayado de contraste medio
+---
+
+- Fondo de selección de texto
+- Fondo del elemento activo / destacado en menús

--- a/src/content/palette/es/iris.md
+++ b/src/content/palette/es/iris.md
@@ -1,0 +1,11 @@
+---
+name: Iris
+description: Aroma a consolidación
+---
+
+- Pistas, sugerencias
+- Caracteres especiales, secuencias de escape
+- Nombres de atributos, propiedades
+- Subrayado de resultados de búsqueda *fuzzy*
+- Cambios en el contenido (p. ej. en diff de Git)
+- En la terminal, magenta y magenta claro

--- a/src/content/palette/es/iris.md
+++ b/src/content/palette/es/iris.md
@@ -1,6 +1,6 @@
 ---
 name: Iris
-description: Aroma a consolidación
+description: Aroma a arraigo
 ---
 
 - Pistas, sugerencias

--- a/src/content/palette/es/love.md
+++ b/src/content/palette/es/love.md
@@ -1,0 +1,8 @@
+---
+name: Love
+description: Per favore ama tutti
+---
+
+- Errores, acciones destructivas
+- Eliminaciones, contenido borrado (p. ej. en diff de Git)
+- En la terminal, rojo y rojo claro

--- a/src/content/palette/es/muted.md
+++ b/src/content/palette/es/muted.md
@@ -1,0 +1,10 @@
+---
+name: Muted
+description: Primer plano de bajo contraste
+---
+
+- Comentarios, anotaciones en la documentación
+- Números de línea, miscelánea en barras de desplazamiento
+- Caracteres no textuales, p. ej. marcadores de espacio, delimitadores
+- Etiquetas de la IU deshabilitadas / atenuadas
+- En la terminal, negro claro

--- a/src/content/palette/es/overlay.md
+++ b/src/content/palette/es/overlay.md
@@ -1,0 +1,10 @@
+---
+name: Overlay
+description: Fondo terciario sobre la superficie
+---
+
+- Elementos de lista activos / destacados, pestañas, entradas de la barra lateral
+- Subrayado de selección visual
+- Fondo de resultados de búsqueda
+- Superficies elevadas, como descripciones y diálogos emergentes
+- En la terminal, negro

--- a/src/content/palette/es/pine.md
+++ b/src/content/palette/es/pine.md
@@ -1,0 +1,9 @@
+---
+name: Pine
+description: Verdor fresco de invierno
+---
+
+- Palabras reservadas, declaraciones, control de flujo
+- Contenido añadido (p. ej. en diff de Git)
+- Señales constructivas o afirmativas
+- En la terminal, verde y verde claro

--- a/src/content/palette/es/pine.md
+++ b/src/content/palette/es/pine.md
@@ -1,6 +1,6 @@
 ---
 name: Pine
-description: Verdor fresco de invierno
+description: Fresco verdor de invierno
 ---
 
 - Palabras reservadas, declaraciones, control de flujo

--- a/src/content/palette/es/rose.md
+++ b/src/content/palette/es/rose.md
@@ -1,0 +1,8 @@
+---
+name: Rose
+description: Una hermosa mas cauta flor
+---
+
+- Llamadas a funciones, nombres de métodos, instrucciones integradas
+- Contenido modificado (p. ej. en diff de Git)
+- En la terminal, cian y cian claro

--- a/src/content/palette/es/subtle.md
+++ b/src/content/palette/es/subtle.md
@@ -1,0 +1,9 @@
+---
+name: Subtle
+description: Primer plano de contraste medio
+---
+
+- Texto secundario, como etiquetas, títulos de pestañas, guías de navegación
+- Texto provisional en cuadros de entrada de texto
+- Texto en paneles inactivos / no enfocados
+- Puntuación, operadores

--- a/src/content/palette/es/surface.md
+++ b/src/content/palette/es/surface.md
@@ -1,0 +1,8 @@
+---
+name: Surface
+description: Fondo secundario sobre la base
+---
+
+- Paneles flotantes, como ventanas emergentes, menús de autocompletado o notificaciones
+- Cuadros de entrada de texto, p. ej. barras de búsqueda, paletas de comandos
+- Barras de estado, barras de título

--- a/src/content/palette/es/surface.md
+++ b/src/content/palette/es/surface.md
@@ -4,5 +4,5 @@ description: Fondo secundario sobre la base
 ---
 
 - Paneles flotantes, como ventanas emergentes, menús de autocompletado o notificaciones
-- Cuadros de entrada de texto, p. ej. barras de búsqueda, paletas de comandos
+- Cuadros de entrada de texto, p. ej. barras de búsqueda o paletas de comandos
 - Barras de estado, barras de título

--- a/src/content/palette/es/text.md
+++ b/src/content/palette/es/text.md
@@ -4,7 +4,7 @@ description: Primer plano de alto contraste
 ---
 
 - Texto principal, nombres de variables, identificadores
-- Texto de la pestaña o elemento activos
+- Texto de la pestaña activa / del elemento destacado
 - Color del cursor, con [Highlight High](/palette/highlight-high) de fondo
 - Primer plano de selección, con [Highlight Med](/palette/highlight-med) de fondo
 - En la terminal, blanco y blanco claro

--- a/src/content/palette/es/text.md
+++ b/src/content/palette/es/text.md
@@ -1,0 +1,10 @@
+---
+name: Text
+description: Primer plano de alto contraste
+---
+
+- Texto principal, nombres de variables, identificadores
+- Texto de la pestaña o elemento activos
+- Color del cursor, con [Highlight High](/palette/highlight-high) de fondo
+- Primer plano de selección, con [Highlight Med](/palette/highlight-med) de fondo
+- En la terminal, blanco y blanco claro

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -38,7 +38,7 @@ export default defineLocale({
 		"home.primary_action": "Explorar temas",
 		"home.feature.colours_and_community.title": "Colores y comunidad",
 		"home.feature.colours_and_community.description":
-			"Rosé Pine es una paleta elegante presente en más de {{REPOS_COUNT}} de tus aplicaciones favoritas, gracias a nuestra simpática y generosa comunidad de contribuidoras/es.",
+			"Rosé Pine es una paleta elegante presente en más de {{REPOS_COUNT}} de tus aplicaciones favoritas, gracias a nuestra simpática y generosa comunidad de contribuyentes.",
 		"home.feature.passionately_subtle.title": "Apasionadamente discreto",
 		"home.feature.passionately_subtle.description":
 			"Con el foco puesto en la calidad y el propósito, nuestros colores están seleccionados para inspirar, no abrumar. Nos emociona que compartas tus creaciones con el mundo.",
@@ -50,7 +50,7 @@ export default defineLocale({
 		"themes.description": "Colección artesanal de personalización.",
 		"themes.all": "Todos",
 		"themes.ports": "Ports",
-		"themes.contributors": "Contribuidoras/es",
+		"themes.contributors": "Contribuyentes",
 		"themes.search_placeholder": "Buscar temas...",
 		"themes.search_focus_cue": "Pulsa / para enfocar",
 
@@ -75,7 +75,7 @@ export default defineLocale({
 		"create.also_available_in": "También disponible en:",
 
 		"submit.title": "Añade un tema",
-		"submit.description": "Envía tu tema para añadirlo a Rosé Pine.",
+		"submit.description": "Propón tu tema para ser añadido a Rosé Pine.",
 		"submit.form.link_label": "Enlace al repositorio",
 		"submit.form.category_label": "Categoría",
 		"submit.form.primary_action": "Enviar",

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -5,24 +5,79 @@ export default defineLocale({
 		name: "Español",
 	},
 	translations: {
-		"nav.home": "Casa",
-		"nav.themes": "Temes",
+		"nav.home": "Inicio",
+		"nav.themes": "Temas",
 		"nav.palette": "Paleta",
+		"nav.create": "Crea",
+		"nav.collections": "Colecciones",
+		"nav.collection.photography": "Fotografía",
+		"nav.collection.made-with": "Hecho con Rosé Pine",
+		"nav.language": "Idioma",
+		"nav.resources": "Recursos",
+		"nav.resource.create": "Crear un tema",
+		"nav.resource.submit": "Añadir un tema",
+		"nav.resource.translate": "Añadir una traducción",
+		"nav.social": "Comunidad",
+		"nav.header_label": "Primario",
+		"nav.footer_label": "Secundario",
+
+		"command.trigger": "Abrir menú de comandos",
+		"command.title": "Menú de comandos",
+		"command.description": "Búsqueda global",
+		"command.search_placeholder": "Buscar páginas, temas y paletas...",
+		"command.close": "Cerrar menú de comandos",
+		"command.empty_results": "No se han encontrado resultados",
+		"command.feeling_lucky": "Voy a tener suerte",
+		"command.recent_themes": "Temas actualizados recientemente",
+		"command.pages": "Páginas",
+		"command.community": "Comunidad",
 
 		"home.title": "Algo bonito",
 		"home.description":
-			"Pino natural, piel sintética y un poco de la atmósfera de Soho para el minimalista con clase",
+			"Pino natural, piel sintética y un poco de la atmósfera del Soho para minimalistas con clase.",
+		"home.primary_action": "Explorar temas",
+		"home.feature.colours_and_community.title": "Colores y comunidad",
+		"home.feature.colours_and_community.description":
+			"Rosé Pine es una paleta elegante presente en más de {{REPOS_COUNT}} de tus aplicaciones favoritas, gracias a nuestra simpática y generosa comunidad de contribuidoras/es.",
+		"home.feature.passionately_subtle.title": "Apasionadamente discreto",
+		"home.feature.passionately_subtle.description":
+			"Con el foco puesto en la calidad y el propósito, nuestros colores están seleccionados para inspirar, no abrumar. Nos emociona que compartas tus creaciones con el mundo.",
+		"home.feature.inclusive_equal_diverse.title": "Inclusividad, igualdad, diversidad",
+		"home.feature.inclusive_equal_diverse.description":
+			"Nos esforzamos a diario para ofrecer un ambiente seguro y motivador para todo el mundo. Encuentra aquí aprecio y consideración.",
 
-		"themes.title": "Temes",
-		"themes.description": "Colección artesanal de personalización",
-		"themes.search_placeholder": "Buscar temas",
+		"themes.title": "Temas",
+		"themes.description": "Colección artesanal de personalización.",
+		"themes.all": "Todos",
+		"themes.ports": "Ports",
+		"themes.contributors": "Contribuidoras/es",
+		"themes.search_placeholder": "Buscar temas...",
+		"themes.search_focus_cue": "Pulsa / para enfocar",
+
+		"colophon.title": "Colofón",
+		"colophon.description": "Las raíces de nuestro jardín.",
+
+		"photography.title": "Fotografía",
+		"photography.description":
+			"Si no te detienes un momento, podrías perderte unas vistas perfectas.",
+
+		"made-with.title": "Hecho con Rosé Pine",
+		"made-with.description": "Proyectos destacados de la comunidad.",
 
 		"palette.title": "Paleta",
+		"palette.description": "Colores selectos, diseñados para inspirar.",
+		"palette.variants": "Variantes",
+		"palette.colours": "Colores",
 
-		"command.search_placeholder": "Buscar páginas, temas y paletas",
-		"command.empty_results": "No se han encontrado resultados",
-		"command.pages": "Páginas",
-		"command.recent_themes": "Temas actualizados recientemente",
-		"command.community": "Comunidad",
+		"create.title": "Crea",
+		"create.description":
+			"Guías, herramientas e inspiración para crear temas preciosos.",
+		"create.also_available_in": "También disponible en:",
+
+		"submit.title": "Añade un tema",
+		"submit.description": "Envía tu tema para añadirlo a Rosé Pine.",
+		"submit.form.link_label": "Enlace al repositorio",
+		"submit.form.category_label": "Categoría",
+		"submit.form.primary_action": "Enviar",
 	},
 });


### PR DESCRIPTION
The main site locale strings already present were rearranged to match the English file, and the code of conduct translation was taken almost verbatim from the [official site](https://www.contributor-covenant.org/es/version/2/0/code_of_conduct/). 

I've checked every file 3 or 4 times, so there shouldn't be any typo I know of. This was translated with the help of the [DRAE](https://dle.rae.es/), some [WordReference](https://wordreference.com/) searches and forum posts and some context cues I got from the Italian translations.