### PR TITLE
add FlorisBoard community theme

### DIFF
--- a/src/content/repos/florisboard.yaml
+++ b/src/content/repos/florisboard.yaml
@@ -1,0 +1,12 @@
+type: community
+name: FlorisBoard
+url: https://github.com/NECOtype/florisboard
+category: system
+updatedAt: 2026-07-30T11:58:00.000Z
+contributors:
+  - name: NECOdes
+    url: https://github.com/NECOtype
+    image: https://avatars.githubusercontent.com/u/89935904?v=4
+tags:
+  - android
+  - keyboard


### PR DESCRIPTION
Hi,
This is a theme for [FlorisBoard](https://github.com/florisboard/florisboard) that I've been using for the past 6 months and I believe is stable enough to be added into repos.
https://github.com/NECOtype/florisboard

All three variants (+borderless versions) are generated using Bloom and packed into `*.flex` archive file which can be imported in the app.

Thank you.